### PR TITLE
add framebuffer-conX-alldata for bulk replacement of connector data

### DIFF
--- a/WhateverGreen.xcodeproj/project.pbxproj
+++ b/WhateverGreen.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 				1C748C281C21952C0024EED2 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		1C748C281C21952C0024EED2 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
This patch adds framebuffer-conX-alldata as discussed here:
https://www.tonymacx86.com/threads/guide-intel-framebuffer-patching-using-whatevergreen.256490/page-14#post-1805692