### PR TITLE
add framebuffer-conX-XXXXXXXX for platform-id specific connector replacement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 WhateverGreen Changelog
 =======================
+#### v1.2.3
+- Added `framebuffer-conX-XXXXXXXX-alldata` IGPU patch support (platform-id specific conX-alldata)
 
 #### v1.2.2
 - Added `framebuffer-conX-alldata` IGPU patch support

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Read [FAQs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/) an
 - [lvs1974](https://applelife.ru/members/lvs1974.53809) for continuous implementation of Intel and NVIDIA fixing code
 - [mologie](https://github.com/mologie/NVWebDriverLibValFix) for creating NVWebDriverLibValFix.kext which forces macOS to recognize NVIDIA's web drivers as platform binaries
 - [PMheart](https://github.com/PMheart) for CoreDisplay patching code and Intel fix backporting
+- [RehabMan](https://github.com/RehabMan) for various enhancements
 - [RemB](https://applelife.ru/members/remb.8064/) for continuing sleep-wake research and finding the right register for AMD issues
 - [Vandroiy](https://applelife.ru/members/vandroiy.83653/) for maintaining the GPU model detection database
 - [YungRaj](https://github.com/YungRaj) and [syscl](https://github.com/syscl) for Intel fix backporting

--- a/WhateverGreen.xcodeproj/project.pbxproj
+++ b/WhateverGreen.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 				MODULE_NAME = as.vit9696.WhateverGreen;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.2.2;
+				MODULE_VERSION = 1.2.3;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -623,7 +623,7 @@
 				MODULE_NAME = as.vit9696.WhateverGreen;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.2.2;
+				MODULE_VERSION = 1.2.3;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -754,7 +754,7 @@
 				MODULE_NAME = as.vit9696.WhateverGreen;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.2.2;
+				MODULE_VERSION = 1.2.3;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -595,8 +595,12 @@ bool IGFX::loadPatchesFromDevice(IORegistryEntry *igpu, uint32_t currentFramebuf
 
 			DBGLOG("igfx", "framebuffer-con%lu-enable %d", i, framebufferConnectorPatchEnable);
 
-			snprintf(name, sizeof(name), "framebuffer-con%lu-alldata", i);
+			snprintf(name, sizeof(name), "framebuffer-con%lu-%08x-alldata", i, currentFramebufferId);
 			auto allData = OSDynamicCast(OSData, igpu->getProperty(name));
+			if (!allData) {
+				snprintf(name, sizeof(name), "framebuffer-con%lu-alldata", i);
+				allData = OSDynamicCast(OSData, igpu->getProperty(name));
+			}
 			if (allData) {
 				auto allDataSize = allData->getLength();
 				auto replaceCount = allDataSize / sizeof(framebufferPatch.connectors[0]);


### PR DESCRIPTION
A slight enhancement to framebuffer-conX-alldata, where you can use framebuffer-conX-XXXXXXXX-alldata.  The -XXXXXXXX makes the patch specific to the active ig-platform-id.  Essentially, conX-XXXXXXXX-alldata, if found matching the current platform-id, overrides conX-alldata.

This allows you to have one set of injections, but different based on ig-platform-id.

In my NUC repo, I needed this as the ig-platform-id can vary depending on device-id (ig-platform-id injected via conditional code in SSDT-IGPU.aml), and I didn't want to inject the patching properties from the AML (would rather keep patching in config.plist for now using Devices/Arbitrary).

A similar capability might make sense for the other patching properties, but I didn't implement it as I have no need so far.