### PR TITLE
SandyBridge framebuffer uses _PlatformInformationList, not _gPlatformInformationList

### DIFF
--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -233,7 +233,7 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 		}
 
 		if (applyFramebufferPatch || dumpFramebufferToDisk || hdmiAutopatch) {
-			gPlatformInformationList = patcher.solveSymbol<void *>(index, "_gPlatformInformationList", address, size);
+			gPlatformInformationList = patcher.solveSymbol<void *>(index, cpuGeneration != CPUInfo::CpuGeneration::SandyBridge ? "_gPlatformInformationList" : "_PlatformInformationList", address, size);
 			if (gPlatformInformationList) {
 				framebufferStart = reinterpret_cast<uint8_t *>(address);
 				framebufferSize = size;


### PR DESCRIPTION
I guess I'm the first to test SandyBridge/HD3000 patching.
Because it doesn't work at all due to AppleIntelSNBGraphicsFB using _PlatformInformationList, not _gPlatformInformationList.
Easy fix in this patch.