### PR TITLE
Platform dump

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,7 @@
 WhateverGreen Changelog
 =======================
 #### v1.2.4
-- Added platform list dumping to ioreg (at IOService:/IOResources/WhateverGreen)
-- Added -igfxnoigdump to disable platform list dumping to iroeg
+- Added platform list dumping to ioreg (at IOService:/IOResources/WhateverGreen), debug build only with -igfxfbdump
 
 #### v1.2.3
 - Added `framebuffer-cursormem` IGPU patch support (Haswell specific)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 WhateverGreen Changelog
 =======================
+#### v1.2.4
+- Added platform list dumping to ioreg (at IOService:/IOResources/WhateverGreen)
+- Added -igfxnoigdump to disable platform list dumping to iroeg
+
 #### v1.2.3
 - Added `framebuffer-cursormem` IGPU patch support (Haswell specific)
 - Added `framebuffer-conX-XXXXXXXX-alldata` IGPU patch support (platform-id specific conX-alldata)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Read [FAQs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/) an
 - `igfxgl=0` to disable Metal support on Intel.
 - `-igfxnohdmi` to disable DP to HDMI conversion patches for digital sound.
 - `-cdfon`  (and `enable-hdmi20` property) to enable HDMI 2.0 patches.
+- `-igfxnoigdump` to disable dump of native and patched ig-platform-id list to ioreg at IOService:/IOResources/WhateverGreen
 
 #### Credits
 - [Apple](https://www.apple.com) for macOS

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Read [FAQs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/) an
 - `-igfxnohdmi` to disable DP to HDMI conversion patches for digital sound.
 - `-cdfon` (and `enable-hdmi20` property) to enable HDMI 2.0 patches.
 - `-igfxdump` to dump IGPU framebuffer kext to `/AppleIntelFramebuffer_X_Y` (available in DEBUG binaries). 
-- `-igfxnoigdump` to disable dump of native and patched ig-platform-id list to ioreg at IOService:/IOResources/WhateverGreen
+- `-igfxfbdump` to dump native and patched framebuffer table to ioreg at IOService:/IOResources/WhateverGreen
 
 #### Credits
 - [Apple](https://www.apple.com) for macOS

--- a/Tools/dump_platformlist.sh
+++ b/Tools/dump_platformlist.sh
@@ -25,7 +25,7 @@ if [[ ! -s /tmp/org.rehabman.platformlist.plist ]]; then
     exit
 fi
 
-for x in preinit native patched; do
+for x in native patched; do
     extract_bin_property $plist :0:platform-table-$x $x.bin
     xxd -groupsize 4 <$x.bin >$x.txt
 done

--- a/WhateverGreen.xcodeproj/project.pbxproj
+++ b/WhateverGreen.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 				MODULE_NAME = as.vit9696.WhateverGreen;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.2.3;
+				MODULE_VERSION = 1.2.4;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -605,7 +605,7 @@
 				MODULE_NAME = as.vit9696.WhateverGreen;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.2.3;
+				MODULE_VERSION = 1.2.4;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",
@@ -736,7 +736,7 @@
 				MODULE_NAME = as.vit9696.WhateverGreen;
 				MODULE_START = "$(PRODUCT_NAME)_kern_start";
 				MODULE_STOP = "$(PRODUCT_NAME)_kern_stop";
-				MODULE_VERSION = 1.2.3;
+				MODULE_VERSION = 1.2.4;
 				OTHER_CFLAGS = (
 					"-mmmx",
 					"-msse",

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -178,7 +178,7 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		hdmiAutopatch = !applyFramebufferPatch && !connectorLessFrame && getKernelVersion() >= Yosemite && !checkKernelArgument("-igfxnohdmi");
 
 		// Disable kext patching if we have nothing to do.
-		switchOffFramebuffer = !blackScreenPatch && !applyFramebufferPatch && !dumpFramebufferToDisk && !hdmiAutopatch;
+		switchOffFramebuffer = !blackScreenPatch && !applyFramebufferPatch && !dumpFramebufferToDisk && !dumpPlatformTable && !hdmiAutopatch;
 		switchOffGraphics = !pavpDisablePatch && !forceOpenGL && !moderniseAccelerator && !avoidFirmwareLoading;
 	} else {
 		switchOffGraphics = switchOffFramebuffer = true;
@@ -235,7 +235,7 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 			patcher.routeMultiple(index, &request, 1, address, size);
 		}
 
-		if (applyFramebufferPatch || dumpFramebufferToDisk || hdmiAutopatch) {
+		if (applyFramebufferPatch || dumpFramebufferToDisk || dumpPlatformTable || hdmiAutopatch) {
 			if (cpuGeneration == CPUInfo::CpuGeneration::SandyBridge) {
 				gPlatformListIsSNB = true;
 				gPlatformInformationList = patcher.solveSymbol<void *>(index, "_PlatformInformationList", address, size);

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -244,6 +244,11 @@ private:
 	bool dumpFramebufferToDisk {false};
 
 	/**
+	 *  Perform platform table dump to ioreg
+	 */
+	bool dumpPlatformTable {true};
+
+	/**
 	 *  Perform automatic DP -> HDMI replacement
 	 */
 	bool hdmiAutopatch {false};
@@ -396,6 +401,24 @@ private:
 	 *  @return pointer to address in data or nullptr
 	 */
 	uint8_t *findFramebufferId(uint32_t framebufferId, uint8_t *startingAddress, size_t maxSize);
+
+	/**
+	 * Calculate total size of platform table list, including termination entry (FFFFFFFF 00000000)
+	 *
+	 * @param startingAddress	Start address of data to search
+	 * @param maxSize			Maximum size of data to search
+	 *
+	 * @return size of data
+	 */
+	static size_t calculatePlatformListSize(uint8_t *startingAddress, size_t maxSize);
+
+	/**
+	 * Write platform table data to ioreg
+	 *
+	 * @param subKeyName		ioreg subkey (under IOService://IOResources/WhateverGreen)
+	 *
+	 */
+	static void writePlatformListData(const char* subKeyName);
 
 	/**
 	 *  Patch data without changing kernel protection

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -244,12 +244,10 @@ private:
 	 */
 	bool dumpFramebufferToDisk {false};
 
-#ifdef DEBUG
 	/**
 	 *  Perform platform table dump to ioreg
 	 */
 	bool dumpPlatformTable {false};
-#endif
 
 	/**
 	 *  Perform automatic DP -> HDMI replacement

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -132,6 +132,7 @@ private:
 	 *  External global variables
 	 */
 	void *gPlatformInformationList {nullptr};
+	bool gPlatformListIsSNB {false};
 
 	/**
 	 *  Private self instance for callbacks
@@ -405,12 +406,11 @@ private:
 	/**
 	 * Calculate total size of platform table list, including termination entry (FFFFFFFF 00000000)
 	 *
-	 * @param startingAddress	Start address of data to search
 	 * @param maxSize			Maximum size of data to search
 	 *
 	 * @return size of data
 	 */
-	static size_t calculatePlatformListSize(uint8_t *startingAddress, size_t maxSize);
+	size_t calculatePlatformListSize(size_t maxSize);
 
 	/**
 	 * Write platform table data to ioreg
@@ -418,7 +418,7 @@ private:
 	 * @param subKeyName		ioreg subkey (under IOService://IOResources/WhateverGreen)
 	 *
 	 */
-	static void writePlatformListData(const char* subKeyName);
+	void writePlatformListData(const char* subKeyName);
 
 	/**
 	 *  Patch data without changing kernel protection

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -244,10 +244,12 @@ private:
 	 */
 	bool dumpFramebufferToDisk {false};
 
+#ifdef DEBUG
 	/**
 	 *  Perform platform table dump to ioreg
 	 */
-	bool dumpPlatformTable {true};
+	bool dumpPlatformTable {false};
+#endif
 
 	/**
 	 *  Perform automatic DP -> HDMI replacement
@@ -403,6 +405,7 @@ private:
 	 */
 	uint8_t *findFramebufferId(uint32_t framebufferId, uint8_t *startingAddress, size_t maxSize);
 
+#ifdef DEBUG
 	/**
 	 * Calculate total size of platform table list, including termination entry (FFFFFFFF 00000000)
 	 *
@@ -416,10 +419,10 @@ private:
 	 * Write platform table data to ioreg
 	 *
 	 * @param subKeyName		ioreg subkey (under IOService://IOResources/WhateverGreen)
-	 *
 	 */
-	void writePlatformListData(const char* subKeyName);
-
+	void writePlatformListData(const char *subKeyName);
+#endif
+	
 	/**
 	 *  Patch data without changing kernel protection
 	 *

--- a/WhateverGreen/kern_shiki.cpp
+++ b/WhateverGreen/kern_shiki.cpp
@@ -155,7 +155,11 @@ void SHIKI::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		auto entry = IORegistryEntry::fromPath("/", gIODTPlane);
 		if (entry) {
 			DBGLOG("shiki", "changing shiki-id to %s", customBoardID);
-			entry->setProperty("shiki-id", OSData::withBytes(customBoardID, static_cast<uint32_t>(strlen(customBoardID)+1)));
+			auto data = OSData::withBytes(customBoardID, static_cast<uint32_t>(strlen(customBoardID)+1));
+			if (data) {
+				entry->setProperty("shiki-id", data);
+				data->release();
+			}
 			entry->release();
 		} else {
 			SYSLOG("shiki", "failed to obtain iodt tree");

--- a/WhateverGreen/kern_weg.cpp
+++ b/WhateverGreen/kern_weg.cpp
@@ -251,7 +251,11 @@ void WEG::processBuiltinProperties(IORegistryEntry *device, DeviceInfo *info) {
 			   realDevice, acpiDevice, fakeDevice, safeString(model));
 		if (model && !obj->getProperty("model")) {
 			DBGLOG("weg", "adding missing model %s from autotodetect", model);
-			obj->setProperty("model", OSData::withBytes(model, static_cast<unsigned>(strlen(model)+1)));
+			auto data = OSData::withBytes(model, static_cast<unsigned>(strlen(model)+1));
+			if (data) {
+				obj->setProperty("model", data);
+				data->release();
+			}
 		}
 
 		// User may request to fake device-id even if it is supported.
@@ -327,8 +331,13 @@ void WEG::processExternalProperties(IORegistryEntry *device, DeviceInfo *info, u
 			WIOKit::getOSDataValue(device, "subsystem-vendor-id", subven) &&
 			WIOKit::getOSDataValue(device, "subsystem-id", sub)) {
 			auto model = getRadeonModel(dev, rev, subven, sub);
-			if (model)
-				device->setProperty("model", OSData::withBytes(model, static_cast<unsigned>(strlen(model)+1)));
+			if (model) {
+				auto data = OSData::withBytes(model, static_cast<unsigned>(strlen(model)+1));
+				if (data) {
+					device->setProperty("model", data);
+					data->release();
+				}
+			}
 		}
 	}
 

--- a/dump_platformlist.sh
+++ b/dump_platformlist.sh
@@ -27,7 +27,7 @@ fi
 
 for x in preinit native patched; do
     extract_bin_property $plist :0:platform-table-$x $x.bin
-    xxd <$x.bin >$x.txt
+    xxd -groupsize 4 <$x.bin >$x.txt
 done
 
 #EOF

--- a/dump_platformlist.sh
+++ b/dump_platformlist.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#set -x
+
+function capture_ioreg_data
+# $1 is node name to search/capture
+# $2 is file name to save XML to
+{
+    ioreg -n $1 -arxw0 >$2
+}
+
+function extract_bin_property
+# $1 is plist file name
+# $2 is path within
+# $3 is file name for binary output
+{
+    local data=$(/usr/libexec/PlistBuddy -x -c "Print :$2" $1 2>&1)
+    data=$([[ "$data" =~ \<data\>(.*)\<\/data\> ]] && echo ${BASH_REMATCH[1]})
+    echo "$data" | base64 --decode >$3
+}
+
+plist=/tmp/org.rehabman.platformlist.plist
+capture_ioreg_data WhateverGreen $plist
+if [[ ! -s /tmp/org.rehabman.platformlist.plist ]]; then
+    echo "Error capturing WhateverGreen registry data (WhateverGreen not installed?)"
+    exit
+fi
+
+for x in preinit native patched; do
+    extract_bin_property $plist :0:platform-table-$x $x.bin
+    xxd <$x.bin >$x.txt
+done
+
+#EOF


### PR DESCRIPTION
This PR adds ig-platform table dumps to ioreg at IOService:/IOResources/WhateverGreen
The data dumped is just the platform table (not the entire kext image).
The dumping is automatic, and is present in release builds (not just debug).
You can disable the dumping with kernel flag: `-igfxnoigdump`

The table is dumped at three separate times:
platform-table-preinit: dumped at the point of gPlatformInformationList (Skylake+ on Mojave and later will show all zeros here, as we know)
platform-table-native: dumped after calling original getOSInformatoin (this is native data after init, prior to patching)
platform-table-patched: dumped after WhateverGreen is done patching

This serves two purposes:
- allowing easy inspection of the native platform-id list
- as a diagnostic tool for seeing the effects of WhateverGreen patching

There is a script included (dump_platformlist.sh) which will generate .bin and .txt files for each of the three dumps.

So, after booting you can do things like:
```
./dump_platformlist.sh
diffmerge native.txt patched.txt
```

Or:
```
./dump_platformlist.sh
open -a "hex fiend" native.bin
```

You can even get the dump in the case you cannot boot with a valid ig-platform-id.  Just make sure you inject "framebuffer-patch-enable"=1 even without any actual patches.

BTW, added this for two reasons:
`-igfxdump` is unreliable (never had it work yet)
`-igfxdump` having just the table is a bit more convenient than the entire in memory kext image

Feel free to squash into one commit.