### PR TITLE
Add PowerColor Radeon R9 270 support

### DIFF
--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -468,6 +468,10 @@ static constexpr Model dev6810[] {
 	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon R9 370X"}
 };
 
+static constexpr Model dev6811[] {
+	{Model::DetectSub, 0x148c, 0x2337, 0x0000, "AMD Radeon R9 270X"},
+};
+
 static constexpr Model dev6818[] {
 	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon HD 7870"}
 };


### PR DESCRIPTION
Adding preliminary support of [PowerColor R9 270 OC gpu](https://www.techpowerup.com/gpu-specs/powercolor-r9-270-oc.b2629)
![screenshot 2019-02-16 at 04 53 53](https://user-images.githubusercontent.com/11856987/52892786-f4a07780-31a6-11e9-9c98-ff436c8a4f79.png)
