### PR TITLE
Set maxLinkRate type to uint32_t so it gets read

### DIFF
--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -452,7 +452,7 @@ private:
 	 *
 	 *  Default value is 0x14 (5.4 Gbps, HBR2) for 4K laptop display
 	 */
-	uint8_t maxLinkRate {0x14};
+	uint32_t maxLinkRate {0x14};
 	
 	/**
 	 *  ReadAUX wrapper to modify the maximum link rate value in the DPCD buffer


### PR DESCRIPTION
Creating this PR at @0xFireWolf's [suggestion](https://github.com/0xFireWolf/WhateverGreen/pull/1#issuecomment-478317374).

The recent DPCD max link rate patch doesn't read `dpcd-max-link-rate` since `getOSDataValue()` is expecting `uint8_t` instead of `uint32_t` and returns false even when `dpcd-max-link-rate` is present. Fix tested and working.

Let me know if there's a better way to accomplish this. Thanks!