### PR TITLE
Fix automatic setting of CFG_FB_LIMIT

### DIFF
--- a/WhateverGreen/kern_rad.cpp
+++ b/WhateverGreen/kern_rad.cpp
@@ -506,7 +506,7 @@ void RAD::updateConnectorsInfo(void *atomutils, t_getAtomObjectTableForType gett
 			if (consPtr && consSize > 0 && *sz > 0 && RADConnectors::valid(consSize, *sz)) {
 				RADConnectors::copy(connectors, *sz, static_cast<const RADConnectors::Connector *>(consPtr), consSize);
 				DBGLOG("rad", "getConnectorsInfo installed %u connectors", *sz);
-				applyPropertyFixes(ctrl, consSize);
+				applyPropertyFixes(ctrl, *sz);
 			} else {
 				DBGLOG("rad", "getConnectorsInfo conoverrides have invalid size %u for %u num", consSize, *sz);
 			}


### PR DESCRIPTION
Previously the incorrect variable was being used causing `CFG_FB_LIMIT` to
be automatically set to the number of bytes in the `connectors` data
instead of the number of connectors.