### PR TITLE
AMD GPU: show real model string when spoofing

### DIFF
--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -741,6 +741,18 @@ static constexpr Model dev6939[] {
 	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon R9 285"}
 };
 
+static constexpr Model dev694c[] {
+	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon RX Vega M GH"}
+};
+
+static constexpr Model dev694e[] {
+	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon RX Vega M GL"}
+};
+
+static constexpr Model dev694f[] {
+	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon Pro WX Vega M GL"}
+};
+
 static constexpr Model dev7300[] {
 	{Model::DetectSub, 0x1002, 0x1b36, 0x0000, "AMD Radeon Pro Duo"},
 	{Model::DetectSub, 0x1043, 0x04a0, 0x0000, "AMD Radeon FURY X"},
@@ -831,6 +843,9 @@ static constexpr DevicePair devices[] {
 	{0x6921, dev6921, arrsize(dev6921)},
 	{0x6938, dev6938, arrsize(dev6938)},
 	{0x6939, dev6939, arrsize(dev6939)},
+	{0x694c, dev694c, arrsize(dev694c)},
+	{0x694e, dev694e, arrsize(dev694e)},
+	{0x694f, dev694f, arrsize(dev694f)},
 	{0x7300, dev7300, arrsize(dev7300)}
 };
 

--- a/WhateverGreen/kern_weg.cpp
+++ b/WhateverGreen/kern_weg.cpp
@@ -363,14 +363,14 @@ void WEG::processExternalProperties(IORegistryEntry *device, DeviceInfo *info, u
 	// This is not necessary for NVIDIA, as their drivers properly detect the name.
 	if (vendor == WIOKit::VendorID::ATIAMD && !device->getProperty("model")) {
 		uint32_t dev, rev, subven, sub;
-		if (WIOKit::getOSDataValue(device, "device-id", dev) &&
-			WIOKit::getOSDataValue(device, "revision-id", rev) &&
-			WIOKit::getOSDataValue(device, "subsystem-vendor-id", subven) &&
-			WIOKit::getOSDataValue(device, "subsystem-id", sub)) {
-			auto model = getRadeonModel(dev, rev, subven, sub);
-			if (model) {
-				device->setProperty("model", const_cast<char *>(model), static_cast<unsigned>(strlen(model)+1));
-			}
+		dev = WIOKit::readPCIConfigValue(device, WIOKit::kIOPCIConfigDeviceID);
+		rev = WIOKit::readPCIConfigValue(device, WIOKit::kIOPCIConfigRevisionID);
+		subven = WIOKit::readPCIConfigValue(device, WIOKit::kIOPCIConfigSubSystemVendorID);
+		sub = WIOKit::readPCIConfigValue(device, WIOKit::kIOPCIConfigSubSystemID);
+		auto model = getRadeonModel(dev, rev, subven, sub);
+		if (model) {
+			device->setProperty("model", const_cast<char *>(model),
+								static_cast<unsigned>(strlen(model)+1));
 		}
 	}
 


### PR DESCRIPTION
It is common to spoof a card's device-id. In that case, the model string displayed should reflect the true card's string instead. We look at the PCI config registers for the real device id instead of the IORegistry.