### PR TITLE
Changed identifier for 67DF / 00CF

### DIFF
--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -407,7 +407,7 @@ static constexpr Model dev67df[] {
 	{Model::DetectRev, 0x0000, 0x0000, 0x00c5, "Radeon RX 470"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00c6, "Radeon RX 570"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00c7, "Radeon RX 480"},
-	{Model::DetectRev, 0x0000, 0x0000, 0x00cf, "Radeon RX 470"},
+	{Model::DetectRev, 0x0000, 0x0000, 0x00cf, "Radeon RX 470/570"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00d7, "Radeon RX 470"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00e0, "Radeon RX 470"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00e7, "Radeon RX 580"},

--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -399,6 +399,7 @@ static constexpr Model dev67c7[] {
 };
 
 static constexpr Model dev67df[] {
+  {Model::DetectSub, 0x1462, 0x341E, 0x0000, "Radeon RX 570 Armor"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00e1, "Radeon RX 590"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00c1, "Radeon RX 580"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00c2, "Radeon RX 570"},

--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -399,7 +399,7 @@ static constexpr Model dev67c7[] {
 };
 
 static constexpr Model dev67df[] {
-  {Model::DetectSub, 0x1462, 0x341E, 0x0000, "Radeon RX 570 Armor"},
+	{Model::DetectSub, 0x1462, 0x341E, 0x0000, "Radeon RX 570 Armor"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00e1, "Radeon RX 590"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00c1, "Radeon RX 580"},
 	{Model::DetectRev, 0x0000, 0x0000, 0x00c2, "Radeon RX 570"},


### PR DESCRIPTION
Hi, I have an RX 570 armor 8GO that identifies with 0x67DF, 0x00CF. It's currently marked as Radeon RX 470 in MacOS.

Seems like it's a common thing to have identifiers shared between Radeon 4XX and 5XX. So I have copied your way of handling this from latest commit 6d4920148feb51ef2e92e36aa42e9a77d68b4d73 to fix the identification.

Hope this helps!

