### PR TITLE
Add codec hardware info spoofing for AMD VCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ WhateverGreen
 - Fixes the infinite loop on establishing Intel HDMI connections with a higher pixel clock rate on Skylake, Kaby Lake and Coffee Lake platforms.
 - Implements the driver support for onboard LSPCON chips to enable DisplayPort to HDMI 2.0 output on some platforms with Intel IGPU.
 - Enforces complete modeset on non-built-in displays on Kaby Lake and newer to fix booting to black screen.
+- Allows non-supported cards to use HW video encoder (`-radcodec`)
 
 #### Documentation
 Read [FAQs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/) and avoid asking any questions. No support is provided for the time being.
@@ -40,6 +41,7 @@ Read [FAQs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/) an
 - `-igfxvesa` to boot Intel graphics without hardware acceleration (VESA mode).
 - `-rad24` to enforce 24-bit display mode.
 - `-raddvi` to enable DVI transmitter correction (required for 290X, 370, etc.).
+- `-radcodec` to force the spoofed PID to be used in AMDRadeonVADriver
 - `radpg=15` to disable several power-gating modes (see FAQ, required for Cape Verde GPUs).
 - `agdpmod=vit9696` disables check for `board-id` (or add `agdpmod` property to external GPU).
 - `agdpmod=pikera` replaces `board-id` with `board-ix`

--- a/WhateverGreen/kern_rad.cpp
+++ b/WhateverGreen/kern_rad.cpp
@@ -1110,5 +1110,5 @@ void RAD::updateGetHWInfo(IOService *accelVideoCtx, void *hwInfo) {
 		WIOKit::getOSDataValue(pciDev, "device-id", dev);
 	}
 	DBGLOG("rad", "getHWInfo: original PID: 0x%04X, replaced PID: 0x%04X", org, dev);
-	org = (uint16_t)dev;
+	org = static_cast<uint16_t>(dev);
 }

--- a/WhateverGreen/kern_rad.cpp
+++ b/WhateverGreen/kern_rad.cpp
@@ -1104,7 +1104,7 @@ void RAD::updateGetHWInfo(IOService *accelVideoCtx, void *hwInfo) {
 		return;
 	}
 	uint16_t &org = getMember<uint16_t>(hwInfo, 0x4);
-	uint32_t dev;
+	uint32_t dev = org;
 	if (!WIOKit::getOSDataValue(pciDev, "codec-device-id", dev)) {
 		// fallback to device-id only if we do not have codec-device-id
 		WIOKit::getOSDataValue(pciDev, "device-id", dev);

--- a/WhateverGreen/kern_rad.hpp
+++ b/WhateverGreen/kern_rad.hpp
@@ -277,13 +277,13 @@ private:
 	/**
 	 *  getHWInfo function type
 	 */
-	using t_getHWInfo = int (*)(IOService *accelVideoCtx, void *hwInfo);
+	using t_getHWInfo = IOReturn (*)(IOService *accelVideoCtx, void *hwInfo);
 
 	/**
 	 *  getHWInfo wrapping functions used for AppleGVA enable patch
 	 */
 	template <size_t Index>
-	static int populateGetHWInfo(IOService *accelVideoCtx, void *hwInfo) {
+	static IOReturn populateGetHWInfo(IOService *accelVideoCtx, void *hwInfo) {
 		if (callbackRAD->orgGetHWInfo[Index]) {
 			int ret = FunctionCast(populateGetHWInfo<Index>, callbackRAD->orgGetHWInfo[Index])(accelVideoCtx, hwInfo);
 			callbackRAD->updateGetHWInfo(accelVideoCtx, hwInfo);
@@ -308,7 +308,8 @@ private:
 	 */
 	const char *getHWInfoProcNames[MaxRadeonHardware] {
 		[RAD::IndexRadeonHardwareX4000] = "__ZN35AMDRadeonX4000_AMDAccelVideoContext9getHWInfoEP13sHardwareInfo",
-		[RAD::IndexRadeonHardwareX5000] = "__ZN35AMDRadeonX5000_AMDAccelVideoContext9getHWInfoEP13sHardwareInfo"
+		[RAD::IndexRadeonHardwareX5000] = "__ZN35AMDRadeonX5000_AMDAccelVideoContext9getHWInfoEP13sHardwareInfo",
+		[RAD::IndexRadeonHardwareX6000] = "__ZN35AMDRadeonX6000_AMDAccelVideoContext9getHWInfoEP13sHardwareInfo"
 	};
 
 	/**

--- a/WhateverGreen/kern_rad.hpp
+++ b/WhateverGreen/kern_rad.hpp
@@ -291,7 +291,7 @@ private:
 		} else {
 			SYSLOG("rad", "populateGetHWInfo invalid use for %lu", Index);
 		}
-		return 1;
+		return kIOReturnInvalid;
 	}
 
 	/**
@@ -299,7 +299,8 @@ private:
 	 */
 	t_getHWInfo wrapGetHWInfo[MaxRadeonHardware] {
 		[RAD::IndexRadeonHardwareX4000] = populateGetHWInfo<RAD::IndexRadeonHardwareX4000>,
-		[RAD::IndexRadeonHardwareX5000] = populateGetHWInfo<RAD::IndexRadeonHardwareX5000>
+		[RAD::IndexRadeonHardwareX5000] = populateGetHWInfo<RAD::IndexRadeonHardwareX5000>,
+		[RAD::IndexRadeonHardwareX6000] = populateGetHWInfo<RAD::IndexRadeonHardwareX6000>
 	};
 
 


### PR DESCRIPTION
When an AMD card is PID spoofed, video encoding does not work because in
AMDRadeonVADriver, `VAAcceleratorInfo::identify` gets the PID by calling
up to AMDRadeonX4000.kext (in a method
`AMDRadeonX4000_AMDAccelVideoContext::getHWInfo` which gets the PID from
`AMDRadeonX4000_AMDHardware::getHWInfo` which is set up by
`AMDRadeonX4000_AMDHardware::initHWInfo` which copies the value from
`AMDRadeonX4000_AMDHardware::init` which reads the PCI registers).

We patch `getHWInfo` to return the spoofed PID (from `device-id`) and this
way, when AppleGVA queries AMDRadeonVADriver, it will no longer return an
error.

Additionally, Shiki patches can be applied to get DRM to work.