### PR TITLE
Add wegtree=0/1 boot argument and rebuild-device-tree property

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ WhateverGreen Changelog
 - Add support to injecting `Force_Load_FalconSMUFW` from OpenCore
 - Disabled automatic enabling of GVA for Polaris on 10.13 and lower
 - Replaced -radnogva argument with radgva=0/1 to force GVA for Polaris
-- Added  `wegtree=1` boot argument (`rebuild-device-tree` property) to force device renaming on Apple FW
+- Added `wegtree=1` boot argument (`rebuild-device-tree` property) to force device renaming on Apple FW
 
 #### v1.3.8
 - Added `igfxfw=2` boot argument and `igfxfw` IGPU property to load Apple GuC firmware

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ WhateverGreen Changelog
 - Add support to injecting `Force_Load_FalconSMUFW` from OpenCore
 - Disabled automatic enabling of GVA for Polaris on 10.13 and lower
 - Replaced -radnogva argument with radgva=0/1 to force GVA for Polaris
+- Added  `wegtree=1` boot argument (`rebuild-device-tree` property) to force device renaming on Apple FW
 
 #### v1.3.8
 - Added `igfxfw=2` boot argument and `igfxfw` IGPU property to load Apple GuC firmware

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ not in the list, the driver's logic is used to determine whether complete modese
 -  `igfxonln=1` boot argument (`force-online` device property) to force online status on all displays.
 -  `igfxonlnfbs=MASK` boot argument (`force-online-framebuffers` device property) to specify
 indices of connectors for which online tatus is enforced. Format is similar to `igfxfcmsfbs`.
+-  `wegtree=1` boot argument (`rebuild-device-tree` property) to force device renaming.
 
 #### Credits
 - [Apple](https://www.apple.com) for macOS

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ not in the list, the driver's logic is used to determine whether complete modese
 -  `igfxonln=1` boot argument (`force-online` device property) to force online status on all displays.
 -  `igfxonlnfbs=MASK` boot argument (`force-online-framebuffers` device property) to specify
 indices of connectors for which online tatus is enforced. Format is similar to `igfxfcmsfbs`.
--  `wegtree=1` boot argument (`rebuild-device-tree` property) to force device renaming.
+-  `wegtree=1` boot argument (`rebuild-device-tree` property) to force device renaming on Apple FW.
 
 #### Credits
 - [Apple](https://www.apple.com) for macOS

--- a/WhateverGreen/kern_weg.cpp
+++ b/WhateverGreen/kern_weg.cpp
@@ -284,18 +284,11 @@ void WEG::processKernel(KernelPatcher &patcher) {
 			bool rebuidTree = checkKernelArgument("-wegtree");
 
 			// Support device properties.
-			if (!rebuidTree) {
-				if (devInfo->videoBuiltin)
-					rebuidTree = devInfo->videoBuiltin->getProperty("rebuild-device-tree") != nullptr;
+			if (!rebuidTree && devInfo->videoBuiltin)
+				rebuidTree = devInfo->videoBuiltin->getProperty("rebuild-device-tree") != nullptr;
 
-				size_t extNum = devInfo->videoExternal.size();
-				for (size_t i = 0; i < extNum; i++) {
-					if (devInfo->videoExternal[i].video->getProperty("rebuild-device-tree")) {
-						rebuidTree = true;
-						break;
-					}
-				}
-			}
+			for (size_t i = 0; !rebuidTree && i < extNum; i++)
+				rebuidTree = devInfo->videoExternal[i].video->getProperty("rebuild-device-tree") != nullptr;
 
 			// Override with modern wegtree argument.
 			int tree;

--- a/WhateverGreen/kern_weg.cpp
+++ b/WhateverGreen/kern_weg.cpp
@@ -280,22 +280,24 @@ void WEG::processKernel(KernelPatcher &patcher) {
 				kextBacklight.switchOff();
 			}
 
-			bool rebuidTree = false;
-			if (checkKernelArgument("-wegtree"))
-				rebuidTree = true;
-			
-			if (devInfo->videoBuiltin)
-				if (devInfo->videoBuiltin->getProperty("rebuild-device-tree"))
-					rebuidTree = true;
+			// Support legacy -wegtree argument.
+			bool rebuidTree = checkKernelArgument("-wegtree");
 
-			size_t extNum = devInfo->videoExternal.size();
-			for (size_t i = 0; i < extNum; i++) {
-				if (devInfo->videoExternal[i].video->getProperty("rebuild-device-tree")) {
-					rebuidTree = true;
-					break;
+			// Support device properties.
+			if (!rebuidTree) {
+				if (devInfo->videoBuiltin)
+					rebuidTree = devInfo->videoBuiltin->getProperty("rebuild-device-tree") != nullptr;
+
+				size_t extNum = devInfo->videoExternal.size();
+				for (size_t i = 0; i < extNum; i++) {
+					if (devInfo->videoExternal[i].video->getProperty("rebuild-device-tree")) {
+						rebuidTree = true;
+						break;
+					}
 				}
 			}
-			
+
+			// Override with modern wegtree argument.
 			int tree;
 			if (PE_parse_boot_argn("wegtree", &tree, sizeof(tree)))
 				rebuidTree = tree != 0;

--- a/WhateverGreen/kern_weg.cpp
+++ b/WhateverGreen/kern_weg.cpp
@@ -280,9 +280,29 @@ void WEG::processKernel(KernelPatcher &patcher) {
 				kextBacklight.switchOff();
 			}
 
-			if (checkKernelArgument("-wegtree")) {
-				DBGLOG("weg", "apple-fw proceeding with devprops due to arg");
+			bool rebuidTree = false;
+			if (checkKernelArgument("-wegtree"))
+				rebuidTree = true;
+			
+			if (devInfo->videoBuiltin)
+				if (devInfo->videoBuiltin->getProperty("rebuild-device-tree"))
+					rebuidTree = true;
 
+			size_t extNum = devInfo->videoExternal.size();
+			for (size_t i = 0; i < extNum; i++) {
+				if (devInfo->videoExternal[i].video->getProperty("rebuild-device-tree")) {
+					rebuidTree = true;
+					break;
+				}
+			}
+			
+			int tree;
+			if (PE_parse_boot_argn("wegtree", &tree, sizeof(tree)))
+				rebuidTree = tree != 0;
+			
+			if (rebuidTree) {
+				DBGLOG("weg", "apple-fw proceeding with devprops by request");
+				
 				if (devInfo->videoBuiltin)
 					processBuiltinProperties(devInfo->videoBuiltin, devInfo);
 


### PR DESCRIPTION
For property mirroring. Note that -wegtree remains as an alias.