### PR TITLE
igfx: use RPS control for all the command streamers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ not in the list, the driver's logic is used to determine whether complete modese
 -  `igfxonlnfbs=MASK` boot argument (`force-online-framebuffers` device property) to specify
 indices of connectors for which online tatus is enforced. Format is similar to `igfxfcmsfbs`.
 -  `wegtree=1` boot argument (`rebuild-device-tree` property) to force device renaming on Apple FW.
+- `igfxnorpsc=1` boot argument (`no-rps-control` property) to disable RPS control patch.
 
 #### Credits
 - [Apple](https://www.apple.com) for macOS

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ WhateverGreen
 - Implements the driver support for onboard LSPCON chips to enable DisplayPort to HDMI 2.0 output on some platforms with Intel IGPU.
 - Enforces complete modeset on non-built-in displays on Kaby Lake and newer to fix booting to black screen.
 - Allows non-supported cards to use HW video encoder (`-radcodec`)
+- Fixes choopy video playback on Intel Kaby Lake and newer. 
 
 #### Documentation
 Read [FAQs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/) and avoid asking any questions. No support is provided for the time being.

--- a/WhateverGreen.xcodeproj/project.pbxproj
+++ b/WhateverGreen.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1C748C2D1C21952C0024EED2 /* kern_start.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C748C2C1C21952C0024EED2 /* kern_start.cpp */; };
 		1C9CB7B01C789FF500231E41 /* kern_rad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C9CB7AE1C789FF500231E41 /* kern_rad.cpp */; };
 		1C9CB7B11C789FF500231E41 /* kern_rad.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1C9CB7AF1C789FF500231E41 /* kern_rad.hpp */; };
+		2F30012424A00F2800C590C3 /* kern_igfx_pm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F30012324A00F2800C590C3 /* kern_igfx_pm.cpp */; };
 		CE1970FF21C380DF00B02AB4 /* kern_nvhda.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE1970FD21C380DF00B02AB4 /* kern_nvhda.cpp */; };
 		CE19710021C380DF00B02AB4 /* kern_nvhda.hpp in Headers */ = {isa = PBXBuildFile; fileRef = CE1970FE21C380DF00B02AB4 /* kern_nvhda.hpp */; };
 		CE1F61B92432DEE800201DF4 /* kern_igfx_debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE1F61B82432DEE800201DF4 /* kern_igfx_debug.cpp */; };
@@ -77,6 +78,7 @@
 		1CF01C901C8CF97F002DCEA3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		1CF01C921C8CF997002DCEA3 /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Changelog.md; sourceTree = "<group>"; };
 		1CF01C931C8DF02E002DCEA3 /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		2F30012324A00F2800C590C3 /* kern_igfx_pm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_igfx_pm.cpp; sourceTree = "<group>"; };
 		CE1970FD21C380DF00B02AB4 /* kern_nvhda.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_nvhda.cpp; sourceTree = "<group>"; };
 		CE1970FE21C380DF00B02AB4 /* kern_nvhda.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_nvhda.hpp; sourceTree = "<group>"; };
 		CE1F61B82432DEE800201DF4 /* kern_igfx_debug.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_igfx_debug.cpp; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 				CE7FC0AC20F5622700138088 /* kern_igfx.cpp */,
 				CE7FC0AD20F5622700138088 /* kern_igfx.hpp */,
 				CE1F61B82432DEE800201DF4 /* kern_igfx_debug.cpp */,
+				2F30012324A00F2800C590C3 /* kern_igfx_pm.cpp */,
 				CE7FC0A820F55E7400138088 /* kern_ngfx.cpp */,
 				CE7FC0A920F55E7400138088 /* kern_ngfx.hpp */,
 				CE7FC0B020F563CA00138088 /* kern_ngfx_asm.S */,
@@ -434,6 +437,7 @@
 				1C9CB7B01C789FF500231E41 /* kern_rad.cpp in Sources */,
 				CE766ED6210763B200A84567 /* kern_guc.cpp in Sources */,
 				CE7FC0B420F6809600138088 /* kern_shiki.cpp in Sources */,
+				2F30012424A00F2800C590C3 /* kern_igfx_pm.cpp in Sources */,
 				CE7FC0B120F563CA00138088 /* kern_ngfx_asm.S in Sources */,
 				CEA03B5E20EE825A00BA842F /* kern_weg.cpp in Sources */,
 				CE8190A21F1E3ECE00DE95F4 /* kern_model.cpp in Sources */,

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -349,6 +349,8 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 				return true;
 			if (disableAGDC)
 				return true;
+			if (RPSControl.enabled)
+				return true;
 			return false;
 		};
 
@@ -364,6 +366,8 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 			if (fwLoadMode != FW_APPLE)
 				return true;
 			if (readDescriptorPatch)
+				return true;
+			if (RPSControl.enabled)
 				return true;
 			return false;
 		};

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -173,6 +173,13 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		dumpPlatformTable = checkKernelArgument("-igfxfbdump");
 		debugFramebuffer = checkKernelArgument("-igfxfbdbg");
 #endif
+		
+		uint32_t nrpsc = 0;
+		if (PE_parse_boot_argn("igfxnorpsc", &nrpsc, sizeof(nrpsc)) ||
+			WIOKit::getOSDataValue(info->videoBuiltin, "no-rps-control", nrpsc)) {
+			DBGLOG("weg", "RPS control patch overriden (%u)", nrpsc);
+			RPSControl.enabled &= !nrpsc;
+		}
 
 		uint32_t forceCompleteModeSet = 0;
 		if (PE_parse_boot_argn("igfxfcms", &forceCompleteModeSet, sizeof(forceCompleteModeSet))) {

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -98,6 +98,7 @@ void IGFX::init() {
 			currentGraphics = &kextIntelKBL;
 			currentFramebuffer = &kextIntelKBLFb;
 			forceCompleteModeset.supported = forceCompleteModeset.enable = true;
+			RPSControl.enabled = true;
 			break;
 		case CPUInfo::CpuGeneration::CoffeeLake:
 			supportsGuCFirmware = true;

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -424,7 +424,7 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 		}
 
 		if (RPSControl.enabled)
-			RPSControl.init(patcher, index, address, size);
+			RPSControl.initGraphics(patcher, index, address, size);
 
 		return true;
 	}
@@ -521,6 +521,9 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 			if (!patcher.routeMultiple(index, &request, 1, address, size))
 				SYSLOG("igfx", "failed to route getDisplayStatus");
 		}
+		
+		if (RPSControl.enabled)
+			RPSControl.initFB(patcher, index, address, size);
 
 		if (disableAGDC) {
 			KernelPatcher::RouteRequest request {"__ZN20IntelFBClientControl11doAttributeEjPmmS0_S0_P25IOExternalMethodArguments", wrapFBClientDoAttribute, orgFBClientDoAttribute};

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -406,16 +406,16 @@ private:
 
 	struct RPSControl {
 		bool enabled {false};
+		uint32_t freq_max {0};
+		
+		void initFB(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size);
+		void initGraphics(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size);
 
-		// Time window in which frequency cannot be dropped.
-		// IGHardwareCommandStreamer2 changes frequency with intervals proportional to RPN-RP0
-		// difference, 4 to 40 ms, for that particular streamer.
-		static constexpr unsigned RPNSWREQ_WINDOW_NS {1000000ULL * 4};
-
-		void init(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size);
-
-		static void IGHardwareCommandStreamer2__setGTFrequencyMMIO(void*,unsigned);
-		mach_vm_address_t orgIGHardwareCommandStreamer2__setGTFrequencyMMIO;
+		static int pmNotifyWrapper(unsigned int,unsigned int,unsigned long long *,unsigned int *);
+		mach_vm_address_t orgPmNotifyWrapper;
+		
+		uint32_t (*AppleIntelFramebufferController__ReadRegister32)(void*,uint32_t) {};
+		void** gController {};
 	} RPSControl;
 
 	/**

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -338,7 +338,7 @@ private:
 	 *  Set to true to disable Metal support
 	 */
 	bool forceOpenGL {false};
-	
+
 	/**
 	 *  Set to true to enable Metal support for offline rendering
 	 */
@@ -403,6 +403,20 @@ private:
 			return false;
 		}
 	};
+
+	struct RPSControl {
+		bool enabled {false};
+
+		// Time window in which frequency cannot be dropped.
+		// IGHardwareCommandStreamer2 changes frequency with intervals proportional to RPN-RP0
+		// difference, 4 to 40 ms, for that particular streamer.
+		static constexpr unsigned RPNSWREQ_WINDOW_NS {1000000ULL * 4};
+
+		void init(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size);
+
+		static void IGHardwareCommandStreamer2__setGTFrequencyMMIO(void*,unsigned);
+		mach_vm_address_t orgIGHardwareCommandStreamer2__setGTFrequencyMMIO;
+	} RPSControl;
 
 	/**
 	 * Ensure each modeset is a complete modeset.

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -14,8 +14,6 @@
 #include <Library/LegacyIOService.h>
 #include "kern_igfx.hpp"
 
-#include <kern/clock.h>
-
 namespace {
 constexpr const char* log = "igfx_pm";
 
@@ -135,6 +133,6 @@ void IGFX::RPSControl::initFB(KernelPatcher &patcher, size_t index, mach_vm_addr
 			orgPmNotifyWrapper
 	};
 
-	if (!(AppleIntelFramebufferController__ReadRegister32 && gController && patcher.routeMultiple(index, &req, address, size, true, true)))
+	if (!(AppleIntelFramebufferController__ReadRegister32 && gController && patcher.routeMultiple(index, &req, 1, address, size, true, true)))
 		SYSLOG(log, "failed to route igfx FB PM functions");
 }

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -129,13 +129,12 @@ void IGFX::RPSControl::initFB(KernelPatcher &patcher, size_t index, mach_vm_addr
 	
 	gController = patcher.solveSymbol<decltype(gController)>(index, "_gController", address, size);
 	
-	KernelPatcher::RouteRequest requests[] {
-		{"__ZL15pmNotifyWrapperjjPyPj",
+	KernelPatcher::RouteRequest req {
+			"__ZL15pmNotifyWrapperjjPyPj",
 			&IGFX::RPSControl::pmNotifyWrapper,
 			orgPmNotifyWrapper
-		}
 	};
 
-	if (!(AppleIntelFramebufferController__ReadRegister32 && gController && patcher.routeMultiple(index, requests, address, size, true, true)))
+	if (!(AppleIntelFramebufferController__ReadRegister32 && gController && patcher.routeMultiple(index, &req, address, size, true, true)))
 		SYSLOG(log, "failed to route igfx FB PM functions");
 }

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -1,0 +1,142 @@
+//
+//  kern_igfx_pm.cpp
+//  WhateverGreen
+//
+//  Created by Pb on 22/06/2020.
+//  Copyright © 2020 vit9696. All rights reserved.
+//
+
+#include <Headers/kern_atomic.hpp>
+#include <Headers/kern_patcher.hpp>
+#include <Headers/kern_devinfo.hpp>
+#include <Headers/kern_cpu.hpp>
+#include <Headers/kern_disasm.hpp>
+#include <Library/LegacyIOService.h>
+#include "kern_igfx.hpp"
+
+#include <kern/clock.h>
+
+namespace {
+constexpr const char* log = "igfx_pm";
+_Atomic(uint32_t) freq_max; // max freq in this time unit
+_Atomic(uint64_t) prev_time_ns; // abs time of previous setGTFrequencyMMIO call
+
+//struct [[gnu::packed]] IGHwCsDesc {
+//  char type;
+//  char gap[4];
+//  char *title;
+//  char unk0[48];
+//  char unk1[12];
+//};
+}
+
+/**
+ * We patch IGHardwareCommandStreamer2::submitExecList to control RPS for any kind of command streamer.
+ * There is no synchronisation between RPNSWREQ access in the original code whatsoever, meaning that
+ * concurrent requests will race, resulting in conflicting frequency setting.
+ * One solution is to maintain a global maximum across all the streamers within RPNSWREQ_WINDOW_NS, and
+ * only allow to decrease the frequency when the window elapses.
+ */
+void IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO(void* streamer, unsigned freq) {
+//	auto cs_desc = getMember<IGHwCsDesc*>(streamer, 0x1c8);
+//	if (cs_desc->type == 1)
+//		freq = 0x22800000;
+//	SYSLOG(log, "setGTFrequencyMMIO freq 0x%x cs_desc->type 0x%x (%s)", freq, cs_desc->type, cs_desc->title);
+
+	uint64_t now, now_ns;
+	clock_get_uptime(&now);
+	absolutetime_to_nanoseconds(now, &now_ns);
+
+	if (now_ns - atomic_load_explicit(&prev_time_ns, memory_order_relaxed) <= RPNSWREQ_WINDOW_NS) {
+		auto freq_curr = atomic_load_explicit(&freq_max, memory_order_relaxed);
+		uint32_t freq_new;
+		
+		do {
+			if (freq > freq_curr)
+				freq_new = freq;
+			else
+				break;
+		} while (!atomic_compare_exchange_weak_explicit(&freq_max, &freq_curr, freq_new,
+														memory_order_relaxed, memory_order_relaxed));
+
+		// Only write the maximum to RPNSWREQ
+		if (freq > freq_curr)
+			FunctionCast(IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO,
+			callbackIGFX->RPSControl.orgIGHardwareCommandStreamer2__setGTFrequencyMMIO)(streamer, freq);
+	} else {
+		// Restart time window
+		atomic_store_explicit(&prev_time_ns, now_ns, memory_order_relaxed);
+		
+		// Use any frequency when restarted
+		atomic_store_explicit(&freq_max, freq, memory_order_relaxed);
+		
+		FunctionCast(IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO,
+		callbackIGFX->RPSControl.orgIGHardwareCommandStreamer2__setGTFrequencyMMIO)(streamer, freq);
+	}
+}
+
+void IGFX::RPSControl::init(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	atomic_store(&freq_max, 0);
+	atomic_store(&prev_time_ns, 0);
+	
+	mach_vm_address_t orgIGHardwareCommandStreamer2__submitExecList {};
+	orgIGHardwareCommandStreamer2__submitExecList = patcher.solveSymbol(index, "__ZN26IGHardwareCommandStreamer214submitExecListEj", address, size);
+	
+	/**
+	 * IGHardwareCommandStreamer2::submitExecList only controls RPS for RCS type streamers.
+	 * Patch it to enable control for any kind of streamer.
+	 */
+	if (orgIGHardwareCommandStreamer2__submitExecList) {
+		mach_vm_address_t start = orgIGHardwareCommandStreamer2__submitExecList;
+		constexpr unsigned ninsts_max {64};
+		
+		hde64s dis;
+		
+		bool found_cmp = false;
+		bool found_jmp = false;
+
+		for (size_t i = 0; i < ninsts_max; i++) {
+			auto sz = Disassembler::hdeDisasm(start, &dis);
+
+			if (dis.flags & F_ERROR) {
+				SYSLOG(log, "Error disassembling submitExecList");
+				break;
+			}
+
+			/* cmp byte ptr [rcx], 0*/
+			if (!found_cmp && dis.opcode == 0x80 && dis.modrm_reg == 7 && dis.modrm_rm == 1)
+				found_cmp = true;
+			/* jnz rel32 */
+			if (found_cmp && dis.opcode == 0x0f && dis.opcode2 == 0x85) {
+				found_jmp = true;
+				break;
+			}
+
+			start += sz;
+		}
+		
+		if (found_jmp) {
+			auto status = MachInfo::setKernelWriting(true, KernelPatcher::kernelWriteLock);
+			if (status == KERN_SUCCESS) {
+				constexpr uint8_t nop6[] {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+				lilu_os_memcpy(reinterpret_cast<void*>(start), nop6, arrsize(nop6));
+				MachInfo::setKernelWriting(false, KernelPatcher::kernelWriteLock);
+				DBGLOG(log, "Patched submitExecList");
+			}
+		} else
+			SYSLOG(log, "jnz in submitExecList not found");
+	} else {
+		SYSLOG(log, "Failed to solve submitExecList (%d)", patcher.getError());
+		patcher.clearError();
+	}
+	
+	KernelPatcher::RouteRequest requests[] {
+		{"__ZN26IGHardwareCommandStreamer218setGTFrequencyMMIOEj",
+			&IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO,
+			orgIGHardwareCommandStreamer2__setGTFrequencyMMIO
+		}
+	};
+
+	if (!patcher.routeMultiple(index, requests, address, size, true, true))
+		SYSLOG(log, "failed to route igfx PM functions");
+}

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -83,7 +83,9 @@ constexpr uint32_t GEN9_FREQ_SCALER  = 3;
 
 void IGFX::RPSControl::initGraphics(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 	mach_vm_address_t orgIGHardwareCommandStreamer2__submitExecList {};
-	orgIGHardwareCommandStreamer2__submitExecList = patcher.solveSymbol(index, "__ZN26IGHardwareCommandStreamer214submitExecListEj", address, size);
+	const char* sym = getKernelVersion() >= KernelVersion::Catalina ?
+	"__ZN26IGHardwareCommandStreamer514submitExecListEj" : "__ZN26IGHardwareCommandStreamer214submitExecListEj";
+	orgIGHardwareCommandStreamer2__submitExecList = patcher.solveSymbol(index, sym, address, size);
 
 	/**
 	 * IGHardwareCommandStreamer2::submitExecList only controls RPS for RCS type streamers.

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -18,125 +18,118 @@
 
 namespace {
 constexpr const char* log = "igfx_pm";
-_Atomic(uint32_t) freq_max; // max freq in this time unit
-_Atomic(uint64_t) prev_time_ns; // abs time of previous setGTFrequencyMMIO call
 
-//struct [[gnu::packed]] IGHwCsDesc {
-//  char type;
-//  char gap[4];
-//  char *title;
-//  char unk0[48];
-//  char unk1[12];
-//};
-}
+// For debugging
+struct [[gnu::packed]] IGHwCsDesc {
+  char type;
+  char gap[4];
+  char *title;
+  char unk0[48];
+  char unk1[12];
+};
 
-/**
- * We patch IGHardwareCommandStreamer2::submitExecList to control RPS for any kind of command streamer.
- * There is no synchronisation between RPNSWREQ access in the original code whatsoever, meaning that
- * concurrent requests will race, resulting in conflicting frequency setting.
- * One solution is to maintain a global maximum across all the streamers within RPNSWREQ_WINDOW_NS, and
- * only allow to decrease the frequency when the window elapses.
- */
-void IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO(void* streamer, unsigned freq) {
-//	auto cs_desc = getMember<IGHwCsDesc*>(streamer, 0x1c8);
-//	if (cs_desc->type == 1)
-//		freq = 0x22800000;
-//	SYSLOG(log, "setGTFrequencyMMIO freq 0x%x cs_desc->type 0x%x (%s)", freq, cs_desc->type, cs_desc->title);
+static bool patchRCSCheck(mach_vm_address_t& start) {
+	constexpr unsigned ninsts_max {256};
+	
+	hde64s dis;
+	
+	bool found_cmp = false;
+	bool found_jmp = false;
 
-	uint64_t now, now_ns;
-	clock_get_uptime(&now);
-	absolutetime_to_nanoseconds(now, &now_ns);
+	for (size_t i = 0; i < ninsts_max; i++) {
+		auto sz = Disassembler::hdeDisasm(start, &dis);
 
-	if (now_ns - atomic_load_explicit(&prev_time_ns, memory_order_relaxed) <= RPNSWREQ_WINDOW_NS) {
-		auto freq_curr = atomic_load_explicit(&freq_max, memory_order_relaxed);
-		uint32_t freq_new;
-		
-		do {
-			if (freq > freq_curr)
-				freq_new = freq;
-			else
-				break;
-		} while (!atomic_compare_exchange_weak_explicit(&freq_max, &freq_curr, freq_new,
-														memory_order_relaxed, memory_order_relaxed));
+		if (dis.flags & F_ERROR) {
+			SYSLOG(log, "Error disassembling submitExecList");
+			break;
+		}
 
-		// Only write the maximum to RPNSWREQ
-		if (freq > freq_curr)
-			FunctionCast(IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO,
-			callbackIGFX->RPSControl.orgIGHardwareCommandStreamer2__setGTFrequencyMMIO)(streamer, freq);
+		/* cmp byte ptr [rcx], 0 */
+		if (!found_cmp && dis.opcode == 0x80 && dis.modrm_reg == 7 && dis.modrm_rm == 1)
+			found_cmp = true;
+		/* jnz rel32 */
+		if (found_cmp && dis.opcode == 0x0f && dis.opcode2 == 0x85) {
+			found_jmp = true;
+			break;
+		}
+
+		start += sz;
+	}
+	
+	if (found_jmp) {
+		auto status = MachInfo::setKernelWriting(true, KernelPatcher::kernelWriteLock);
+		if (status == KERN_SUCCESS) {
+			constexpr uint8_t nop6[] {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+			lilu_os_memcpy(reinterpret_cast<void*>(start), nop6, arrsize(nop6));
+			MachInfo::setKernelWriting(false, KernelPatcher::kernelWriteLock);
+			DBGLOG(log, "Patched submitExecList");
+			return true;
+		} else {
+			DBGLOG(log, "Failed to set kernel writing");
+			return false;
+		}
 	} else {
-		// Restart time window
-		atomic_store_explicit(&prev_time_ns, now_ns, memory_order_relaxed);
-		
-		// Use any frequency when restarted
-		atomic_store_explicit(&freq_max, freq, memory_order_relaxed);
-		
-		FunctionCast(IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO,
-		callbackIGFX->RPSControl.orgIGHardwareCommandStreamer2__setGTFrequencyMMIO)(streamer, freq);
+		SYSLOG(log, "jnz in submitExecList not found");
+		return false;
 	}
 }
 
-void IGFX::RPSControl::init(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
-	atomic_store(&freq_max, 0);
-	atomic_store(&prev_time_ns, 0);
-	
+constexpr uint32_t GEN6_RP_STATE_CAP = 0x140000 + 0x5998;
+}
+
+void IGFX::RPSControl::initGraphics(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 	mach_vm_address_t orgIGHardwareCommandStreamer2__submitExecList {};
 	orgIGHardwareCommandStreamer2__submitExecList = patcher.solveSymbol(index, "__ZN26IGHardwareCommandStreamer214submitExecListEj", address, size);
-	
+
 	/**
 	 * IGHardwareCommandStreamer2::submitExecList only controls RPS for RCS type streamers.
 	 * Patch it to enable control for any kind of streamer.
 	 */
 	if (orgIGHardwareCommandStreamer2__submitExecList) {
 		mach_vm_address_t start = orgIGHardwareCommandStreamer2__submitExecList;
-		constexpr unsigned ninsts_max {64};
-		
-		hde64s dis;
-		
-		bool found_cmp = false;
-		bool found_jmp = false;
-
-		for (size_t i = 0; i < ninsts_max; i++) {
-			auto sz = Disassembler::hdeDisasm(start, &dis);
-
-			if (dis.flags & F_ERROR) {
-				SYSLOG(log, "Error disassembling submitExecList");
-				break;
-			}
-
-			/* cmp byte ptr [rcx], 0*/
-			if (!found_cmp && dis.opcode == 0x80 && dis.modrm_reg == 7 && dis.modrm_rm == 1)
-				found_cmp = true;
-			/* jnz rel32 */
-			if (found_cmp && dis.opcode == 0x0f && dis.opcode2 == 0x85) {
-				found_jmp = true;
-				break;
-			}
-
-			start += sz;
-		}
-		
-		if (found_jmp) {
-			auto status = MachInfo::setKernelWriting(true, KernelPatcher::kernelWriteLock);
-			if (status == KERN_SUCCESS) {
-				constexpr uint8_t nop6[] {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
-				lilu_os_memcpy(reinterpret_cast<void*>(start), nop6, arrsize(nop6));
-				MachInfo::setKernelWriting(false, KernelPatcher::kernelWriteLock);
-				DBGLOG(log, "Patched submitExecList");
-			}
-		} else
-			SYSLOG(log, "jnz in submitExecList not found");
+		patchRCSCheck(start);
+		// The second patch is to get to patchFrequencyRequest (unused for now)
+//		patchRCSCheck(start);
 	} else {
 		SYSLOG(log, "Failed to solve submitExecList (%d)", patcher.getError());
 		patcher.clearError();
 	}
+}
+
+/**
+ * Request maximum RPS at exec list submission.
+ * While this sounds dangerous, there appears to be a secondary mechanism
+ * that downclocks the GPU rather quickly back.
+ * Using any lower RPS lets that mechanism win the race.
+ */
+int IGFX::RPSControl::pmNotifyWrapper(unsigned int a0,unsigned int a1,unsigned long long * a2,unsigned int * freq) {
+	uint32_t cfreq = 0;
+
+	FunctionCast(IGFX::RPSControl::pmNotifyWrapper, callbackIGFX->RPSControl.orgPmNotifyWrapper)(a0, a1, a2, &cfreq);
+	
+	if (!callbackIGFX->RPSControl.freq_max) {
+		callbackIGFX->RPSControl.freq_max = callbackIGFX->RPSControl.AppleIntelFramebufferController__ReadRegister32(*callbackIGFX->RPSControl.gController, GEN6_RP_STATE_CAP) & 0xff;
+		DBGLOG(log, "Read RP0 %d", callbackIGFX->RPSControl.freq_max);
+	}
+	
+	DBGLOG(log, "pmNotifyWrapper sets freq 0x%x", cfreq);
+	*freq = 0x1800000 * callbackIGFX->RPSControl.freq_max;
+
+	return 0;
+}
+
+void IGFX::RPSControl::initFB(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	AppleIntelFramebufferController__ReadRegister32 = patcher.solveSymbol<decltype(AppleIntelFramebufferController__ReadRegister32)>(index, "__ZN31AppleIntelFramebufferController14ReadRegister32Em", address, size);
+	
+	gController = patcher.solveSymbol<decltype(gController)>(index, "_gController", address, size);
 	
 	KernelPatcher::RouteRequest requests[] {
-		{"__ZN26IGHardwareCommandStreamer218setGTFrequencyMMIOEj",
-			&IGFX::RPSControl::IGHardwareCommandStreamer2__setGTFrequencyMMIO,
-			orgIGHardwareCommandStreamer2__setGTFrequencyMMIO
+		{"__ZL15pmNotifyWrapperjjPyPj",
+			&IGFX::RPSControl::pmNotifyWrapper,
+			orgPmNotifyWrapper
 		}
 	};
 
-	if (!patcher.routeMultiple(index, requests, address, size, true, true))
-		SYSLOG(log, "failed to route igfx PM functions");
+	if (!(AppleIntelFramebufferController__ReadRegister32 && gController && patcher.routeMultiple(index, requests, address, size, true, true)))
+		SYSLOG(log, "failed to route igfx FB PM functions");
 }

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -74,7 +74,11 @@ static bool patchRCSCheck(mach_vm_address_t& start) {
 	}
 }
 
-constexpr uint32_t GEN6_RP_STATE_CAP = 0x140000 + 0x5998;
+constexpr uint32_t MCHBAR_MIRROR_BASE_SNB = 0x140000;
+constexpr uint32_t GEN6_RP_STATE_CAP = MCHBAR_MIRROR_BASE_SNB + 0x5998;
+
+constexpr uint32_t GEN9_FREQUENCY_SHIFT = 23;
+constexpr uint32_t GEN9_FREQ_SCALER  = 3;
 }
 
 void IGFX::RPSControl::initGraphics(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
@@ -113,7 +117,7 @@ int IGFX::RPSControl::pmNotifyWrapper(unsigned int a0,unsigned int a1,unsigned l
 	}
 	
 	DBGLOG(log, "pmNotifyWrapper sets freq 0x%x", cfreq);
-	*freq = 0x1800000 * callbackIGFX->RPSControl.freq_max;
+	*freq = (GEN9_FREQ_SCALER << GEN9_FREQUENCY_SHIFT) * callbackIGFX->RPSControl.freq_max;
 
 	return 0;
 }


### PR DESCRIPTION
This should fix choppy GPU-accelerated video playback. See `kern_igfx_pm.cpp` for details.

Tested on UHD630 CFL. In order to enable, ensure kernel log contains:

```
[IGPU] Scheduler: PM notify enabled
[IGPU] Graphics accelerator is using scheduler: Host Priority Scheduler
```

Possible action items:

- Tweak `RPNSWREQ_WINDOW_NS`

- Check if any other GEN versions suffer from the same problem, and port the code for them