### PR TITLE
Add first generation Intel HD Graphics support

### DIFF
--- a/Manual/FAQ.IntelHD.en.md
+++ b/Manual/FAQ.IntelHD.en.md
@@ -79,6 +79,42 @@ Unlike in `Properties` the normal byte order and the `0x` prefix are to be used.
 
 - If a framebuffer is not specified explicitly in any way, the default framebuffer will be injected.  
 - If a framebuffer is not set and the system has a discrete graphics card, an "empty framebuffer" will be injected.  
+
+## Intel HD Graphics (first generation / Ironlake) ([Arrandale](https://en.wikipedia.org/wiki/Arrandale) processors)  
+
+> Supported from Mac OS X 10.6.x to macOS 10.13.6. The instructions are for OS X 10.8.x - macOS 10.13.6 and are unsupported on newer operating systems. Metal support is absent.  
+> Laptops with LVDS displays are the only supported combination. All other display types are unsupported.    
+
+> For more information, reference [this](https://github.com/Goldfish64/ArrandaleGraphicsHackintosh) and [this](https://www.insanelymac.com/forum/topic/286092-guide-1st-generation-intel-hd-graphics-qeci/).
+
+Most typical configuration will require `framebuffer-patch-enable` and `framebuffer-singlelink`. `AAPL,ig-platform-id` is not required.
+
+If there are display or wake issues, `framebuffer-fbccontrol-*` and `framebuffer-featurecontrol-*` properties may be helpful. These mirror the settings present in the `Info.plist` of the framebuffer kext and are simple 0 or 1 settings.
+
+**Semantic:**  
+*framebuffer-patch-enable (enable patching)  
+framebuffer-linkwidth (specify link width, default is 1)  
+framebuffer-singlelink (enable single link mode)*  
+
+**FBCControl:**  
+*framebuffer-fbccontrol-allzero (sets all properties to zero, ones below will override)  
+framebuffer-fbccontrol-compression*  
+
+**FeatureControl:**  
+*framebuffer-featurecontrol-allzero (sets all properties to zero, ones below will override)  
+framebuffer-featurecontrol-fbc  
+framebuffer-featurecontrol-gpuinterrupthandling  
+framebuffer-featurecontrol-gamma  
+framebuffer-featurecontrol-maximumselfrefreshlevel  
+framebuffer-featurecontrol-powerstates  
+framebuffer-featurecontrol-rstimertest  
+framebuffer-featurecontrol-renderstandby  
+framebuffer-featurecontrol-watermarks*  
+
+***Native supported DevID's:*** 
+
+- `0x0042`
+- `0x0046`
   
 ## Intel HD Graphics 2000/3000 ([Sandy Bridge](https://en.wikipedia.org/wiki/Sandy_Bridge) processors)  
 

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -2617,6 +2617,7 @@ void IGFX::applyWestmereFeaturePatches(IOService *framebuffer) {
 		// Replace FBCControl dictionary.
 		framebuffer->removeProperty("FBCControl");
 		success &= framebuffer->setProperty("FBCControl", dictFBCControlNew);
+		dictFBCControlNew->release();
 	}
 	
 	if (patchFeatureControl) {
@@ -2643,6 +2644,7 @@ void IGFX::applyWestmereFeaturePatches(IOService *framebuffer) {
 		// Replace FBCControl dictionary.
 		framebuffer->removeProperty("FeatureControl");
 		success &= framebuffer->setProperty("FeatureControl", dictFeatureControlNew);
+		dictFeatureControlNew->release();
 	}
 	
 	if (success)

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -47,6 +47,7 @@ private:
 	 *  Framebuffer patch flags
 	 */
 	union FramebufferPatchFlags {
+		// Sandy+ bits
 		struct FramebufferPatchFlagBits {
 			uint8_t FPFFramebufferId            :1;
 			uint8_t FPFModelNameAddr            :1;
@@ -71,6 +72,22 @@ private:
 			uint8_t FPFSliceCount               :1;
 			uint8_t FPFEuCount                  :1;
 		} bits;
+		
+		// Westmere bits
+		struct FramebufferWestmerePatchFlagBits {
+			uint8_t LinkWidth                               : 1;
+			uint8_t SingleLink                              : 1;
+			uint8_t FBCControlCompression                   : 1;
+			uint8_t FeatureControlFBC                       : 1;
+			uint8_t FeatureControlGPUInterruptHandling      : 1;
+			uint8_t FeatureControlGamma                     : 1;
+			uint8_t FeatureControlMaximumSelfRefreshLevel   : 1;
+			uint8_t FeatureControlPowerStates               : 1;
+			uint8_t FeatureControlRSTimerTest               : 1;
+			uint8_t FeatureControlRenderStandby             : 1;
+			uint8_t FeatureControlWatermarks                : 1;
+		} bitsWestmere;
+		
 		uint32_t value;
 	};
 
@@ -157,26 +174,6 @@ private:
 	FramebufferPatch framebufferPatches[MaxFramebufferPatchCount] {};
 	
 	/**
-	 *  Framebuffer patch flags for first generation (Westmere).
-	 */
-	union FramebufferWestmerePatchFlags {
-		struct FramebufferWestmerePatchFlagBits {
-			uint8_t LinkWidth                               : 1;
-			uint8_t SingleLink                              : 1;
-			uint8_t FBCControlCompression                   : 1;
-			uint8_t FeatureControlFBC                       : 1;
-			uint8_t FeatureControlGPUInterruptHandling      : 1;
-			uint8_t FeatureControlGamma                     : 1;
-			uint8_t FeatureControlMaximumSelfRefreshLevel   : 1;
-			uint8_t FeatureControlPowerStates               : 1;
-			uint8_t FeatureControlRSTimerTest               : 1;
-			uint8_t FeatureControlRenderStandby             : 1;
-			uint8_t FeatureControlWatermarks                : 1;
-		} bits;
-		uint32_t value;
-	};
-	
-	/**
 	 *  Framebuffer patches for first generation (Westmere).
 	 */
 	struct FramebufferWestmerePatches {
@@ -193,11 +190,6 @@ private:
 		uint32_t FeatureControlRenderStandby {0};
 		uint32_t FeatureControlWatermarks {0};
 	};
-	
-	/**
-	 *  Framebuffer patch flags for first generation (Westmere).
-	 */
-	FramebufferWestmerePatchFlags framebufferWestmerePatchFlags;
 	
 	/**
 	 *  Framebuffer patches for first generation (Westmere).

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -155,6 +155,54 @@ private:
 	 *  Framebuffer find / replace patches
 	 */
 	FramebufferPatch framebufferPatches[MaxFramebufferPatchCount] {};
+	
+	/**
+	 *  Framebuffer patch flags for first generation (Westmere).
+	 */
+	union FramebufferWestmerePatchFlags {
+		struct FramebufferWestmerePatchFlagBits {
+			uint8_t LinkWidth								: 1;
+			uint8_t SingleLink								: 1;
+			uint8_t FBCControlCompression 					: 1;
+			uint8_t FeatureControlFBC						: 1;
+			uint8_t FeatureControlGPUInterruptHandling		: 1;
+			uint8_t FeatureControlGamma						: 1;
+			uint8_t FeatureControlMaximumSelfRefreshLevel	: 1;
+			uint8_t FeatureControlPowerStates				: 1;
+			uint8_t FeatureControlRSTimerTest				: 1;
+			uint8_t FeatureControlRenderStandby				: 1;
+			uint8_t FeatureControlWatermarks				: 1;
+		} bits;
+		uint32_t value;
+	};
+	
+	/**
+	 *  Framebuffer patches for first generation (Westmere).
+	 */
+	struct FramebufferWestmerePatches {
+		uint32_t LinkWidth {1};
+		uint32_t SingleLink {0};
+		
+		uint32_t FBCControlCompression {0};
+		uint32_t FeatureControlFBC {0};
+		uint32_t FeatureControlGPUInterruptHandling {0};
+		uint32_t FeatureControlGamma {0};
+		uint32_t FeatureControlMaximumSelfRefreshLevel {0};
+		uint32_t FeatureControlPowerStates {0};
+		uint32_t FeatureControlRSTimerTest {0};
+		uint32_t FeatureControlRenderStandby {0};
+		uint32_t FeatureControlWatermarks {0};
+	};
+	
+	/**
+	 *  Framebuffer patch flags for first generation (Westmere).
+	 */
+	FramebufferWestmerePatchFlags framebufferWestmerePatchFlags;
+	
+	/**
+	 *  Framebuffer patches for first generation (Westmere).
+	 */
+	FramebufferWestmerePatches framebufferWestmerePatches;
 
 	/**
 	 *  Framebuffer list, imported from the framebuffer kext
@@ -1361,7 +1409,7 @@ private:
 	/**
 	 *  AppleIntelFramebufferController::getOSInformation wrapper to patch framebuffer data
 	 */
-	static bool wrapGetOSInformation(void *that);
+	static bool wrapGetOSInformation(IOService *that);
 
 	/**
 	 *  IGHardwareGuC::loadGuCBinary wrapper to feed updated (compatible GuC)
@@ -1487,6 +1535,17 @@ private:
 	 *  @return true if patched anything
 	 */
 	bool applyPatch(const KernelPatcher::LookupPatch &patch, uint8_t *startingAddress, size_t maxSize);
+	
+	/**
+	 *  Add int to dictionary.
+	 *
+	 *  @param dict		OSDictionary instance.
+	 *  @param key		Key to add.
+	 *  @param value 	Value to add.
+	 *
+	 *  @return true if added
+	 */
+	bool setDictUInt32(OSDictionary *dict, const char *key, UInt32 value);
 
 	/**
 	 *  Patch platformInformationList
@@ -1528,6 +1587,16 @@ private:
 	 *  Apply DP to HDMI automatic connector type changes
 	 */
 	void applyHdmiAutopatch();
+	
+	/**
+	 *	Apply patches for first generation framebuffer.
+	 */
+	void applyWestmerePatches(KernelPatcher &patcher);
+	
+	/**
+	 *	Apply I/O registry FeatureControl and FBCControl patches for first generation framebuffer.
+	 */
+	void applyWestmereFeaturePatches(IOService *framebuffer);
 };
 
 #endif /* kern_igfx_hpp */

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -163,7 +163,7 @@ private:
 		struct FramebufferWestmerePatchFlagBits {
 			uint8_t LinkWidth								: 1;
 			uint8_t SingleLink								: 1;
-			uint8_t FBCControlCompression 					: 1;
+			uint8_t FBCControlCompression					: 1;
 			uint8_t FeatureControlFBC						: 1;
 			uint8_t FeatureControlGPUInterruptHandling		: 1;
 			uint8_t FeatureControlGamma						: 1;

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -161,17 +161,17 @@ private:
 	 */
 	union FramebufferWestmerePatchFlags {
 		struct FramebufferWestmerePatchFlagBits {
-			uint8_t LinkWidth								: 1;
-			uint8_t SingleLink								: 1;
-			uint8_t FBCControlCompression					: 1;
-			uint8_t FeatureControlFBC						: 1;
-			uint8_t FeatureControlGPUInterruptHandling		: 1;
-			uint8_t FeatureControlGamma						: 1;
-			uint8_t FeatureControlMaximumSelfRefreshLevel	: 1;
-			uint8_t FeatureControlPowerStates				: 1;
-			uint8_t FeatureControlRSTimerTest				: 1;
-			uint8_t FeatureControlRenderStandby				: 1;
-			uint8_t FeatureControlWatermarks				: 1;
+			uint8_t LinkWidth                               : 1;
+			uint8_t SingleLink                              : 1;
+			uint8_t FBCControlCompression                   : 1;
+			uint8_t FeatureControlFBC                       : 1;
+			uint8_t FeatureControlGPUInterruptHandling      : 1;
+			uint8_t FeatureControlGamma                     : 1;
+			uint8_t FeatureControlMaximumSelfRefreshLevel   : 1;
+			uint8_t FeatureControlPowerStates               : 1;
+			uint8_t FeatureControlRSTimerTest               : 1;
+			uint8_t FeatureControlRenderStandby             : 1;
+			uint8_t FeatureControlWatermarks                : 1;
 		} bits;
 		uint32_t value;
 	};


### PR DESCRIPTION
First generation Intel HD Graphics (Ironlake) support for 10.8.x to 10.13.x, along with appropriate English documentation updates. Patches are configured using device properties similar to newer HD Graphics versions, with `-igfxvesa` and `-igfxdump` supported.