### PR TITLE
New way to patch backlight on Kaby Lake and older

### DIFF
--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -1805,7 +1805,7 @@ void IGFX::wrapCflWriteRegister32(void *that, uint32_t reg, uint32_t value) {
 	} else if (reg == BXT_BLC_PWM_DUTY1) {
 		if (callbackIGFX->driverBacklightFrequency && callbackIGFX->targetBacklightFrequency) {
 			// Translate the PWM duty cycle between the driver scale value and the HW scale value
-			uint32_t rescaledValue = static_cast<uint32_t>((value * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
+			uint32_t rescaledValue = static_cast<uint32_t>((static_cast<uint64_t>(value) * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
 				static_cast<uint64_t>(callbackIGFX->driverBacklightFrequency));
 			DBGLOG("igfx", "wrapCflWriteRegister32: write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x", value,
 				   callbackIGFX->driverBacklightFrequency, rescaledValue, callbackIGFX->targetBacklightFrequency);
@@ -1841,7 +1841,7 @@ void IGFX::wrapKblWriteRegister32(void *that, uint32_t reg, uint32_t value) {
 		uint16_t frequency = (value & 0xffff0000U) >> 16U;
 		uint16_t dutyCycle = value & 0xffffU;
 
-		uint32_t rescaledValue = frequency == 0 ? 0 : static_cast<uint32_t>((dutyCycle * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
+		uint32_t rescaledValue = frequency == 0 ? 0 : static_cast<uint32_t>((static_cast<uint64_t>(dutyCycle) * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
 										    static_cast<uint64_t>(frequency));
 		DBGLOG("igfx", "wrapKblWriteRegister32: write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x",
 			   dutyCycle, frequency, rescaledValue, callbackIGFX->targetBacklightFrequency);
@@ -1894,7 +1894,7 @@ void IGFX::wrapHswWriteRegister32(void *that, uint32_t reg, uint32_t value) {
 		uint32_t dutyCycle = value & 0xffffU;
 		uint32_t frequency = (value & 0xffff0000U) >> 16U;
 
-		uint32_t rescaledDutyCycle = frequency == 0 ? 0 : static_cast<uint32_t>((dutyCycle * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
+		uint32_t rescaledDutyCycle = frequency == 0 ? 0 : static_cast<uint32_t>((static_cast<uint64_t>(dutyCycle) * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
 											static_cast<uint64_t>(frequency));
 
 		if (frequency) {
@@ -1939,7 +1939,7 @@ void IGFX::wrapIvyWriteRegister32(void *that, uint32_t reg, uint32_t value) {
 	} else if (reg == BLC_PWM_CPU_CTL) {
 		if (callbackIGFX->driverBacklightFrequency && callbackIGFX->targetBacklightFrequency) {
 			// Translate the PWM duty cycle between the driver scale value and the HW scale value
-			uint32_t rescaledValue = static_cast<uint32_t>((value * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
+			uint32_t rescaledValue = static_cast<uint32_t>((static_cast<uint64_t>(value) * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
 				static_cast<uint64_t>(callbackIGFX->driverBacklightFrequency));
 			DBGLOG("igfx", "wrapIvyWriteRegister32: write BLC_PWM_CPU_CTL 0x%x/0x%x, rescaled to 0x%x/0x%x", value,
 				   callbackIGFX->driverBacklightFrequency, rescaledValue, callbackIGFX->targetBacklightFrequency);

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -555,7 +555,7 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 			//   hardcoded frequencies. 65535 is used by default.
 			// - If [PWM Base Frequency] is > 65535, to avoid a wraparound code calculating BXT_BLC_PWM_DUTY1
 			//   should be replaced to use 64-bit arithmetics.
-			// [PWM Base Frequency] can be specified via igfxbklt=1 boot-arg or backlight-base-frequency property.
+			// [PWM Base Frequency] can be specified via max-backlight-freq property.
 
 			// This patch will overwrite WriteRegister32 function to rescale all the register writes of backlight controller.
 			// Slightly different methods are used for CFL hardware running on KBL and CFL drivers.

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -144,6 +144,7 @@ private:
 	/**
 	 *  Backlight registers
 	 */
+	static constexpr uint32_t BLC_PWM_CPU_CTL = 0x48254;
 	static constexpr uint32_t BXT_BLC_PWM_CTL1 = 0xC8250;
 	static constexpr uint32_t BXT_BLC_PWM_FREQ1 = 0xC8254;
 	static constexpr uint32_t BXT_BLC_PWM_DUTY1 = 0xC8258;
@@ -297,12 +298,16 @@ private:
 	uint32_t (*orgCflReadRegister32)(void *, uint32_t) {nullptr};
 	uint32_t (*orgKblReadRegister32)(void *, uint32_t) {nullptr};
 	uint32_t (*orgIclReadRegister32)(void *, uint32_t) {nullptr};
+	uint32_t (*orgHswReadRegister32)(void *, uint32_t) {nullptr};
+	uint32_t (*orgIvyReadRegister32)(void *, uint32_t) {nullptr};
 
 	/**
 	 *  Original AppleIntelFramebufferController::WriteRegister32 function
 	 */
 	void (*orgCflWriteRegister32)(void *, uint32_t, uint32_t) {nullptr};
 	void (*orgKblWriteRegister32)(void *, uint32_t, uint32_t) {nullptr};
+	void (*orgHswWriteRegister32)(void *, uint32_t, uint32_t) {nullptr};
+	void (*orgIvyWriteRegister32)(void *, uint32_t, uint32_t) {nullptr};
 
 	/**
 	 *  Original AppleIntelFramebufferController::ReadAUX function
@@ -367,6 +372,11 @@ private:
 	 *  - laptop with CFL CPU and CFL IGPU drivers turns patch on
 	 */
 	CoffeeBacklightPatch cflBacklightPatch {CoffeeBacklightPatch::Off};
+
+	/**
+	 *  Set to true to enable new backlight patch type for Kaby Lake and older
+	 */
+	bool newBacklightPatch {false};
 
 	/**
 	 *  Patch the maximum link rate in the DPCD buffer read from the built-in display
@@ -1661,6 +1671,8 @@ private:
 	 */
 	static void wrapCflWriteRegister32(void *that, uint32_t reg, uint32_t value);
 	static void wrapKblWriteRegister32(void *that, uint32_t reg, uint32_t value);
+	static void wrapHswWriteRegister32(void *that, uint32_t reg, uint32_t value);
+	static void wrapIvyWriteRegister32(void *that, uint32_t reg, uint32_t value);
 
 	/**
 	 *  AppleIntelFramebufferController::getOSInformation wrapper to patch framebuffer data


### PR DESCRIPTION
Hi, this pull request adds a new backlight patch for Kaby Lake and older based on the Coffee Lake backlight patch. It removes the need of injecting custom PWMMax with SSDT-PNLF, allowing using the default PWMMax system firmware.

With this patch, we can use SSDT-PNLFCFL for any platforms, just need to change _UID.

Tested on KabyLake (HD620)

P/s: This is my first time working with Intel graphics patching. If I did anything wrong, please help me correct it. Thank you very much!