### PR TITLE
IGFX: Convert existing patches to submodules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 WhateverGreen Changelog
 =======================
+#### v1.4.6
+- Backlight registers fix replaces the previous Coffee Lake backlight fix and is now available on Intel Ice Lake platforms.
+- Boot argument `igfxcflbklt=1` as well as device property `enable-cfl-backlight-fix` are deprecated and replaced by `-igfxblr` and `enable-backlight-registers-fix`.
+
 #### v1.4.5
 - Enabled loading in safe mode (mainly for AGDP fixes)
 - Resolved an issue that the maximum link rate fix is not working properly on Intel Comet Lake platforms. (Thanks @CoronaHack)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Read [FAQs](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/) an
 - `-cdfon` (and `enable-hdmi20` property) to enable HDMI 2.0 patches.
 - `-igfxdump` to dump IGPU framebuffer kext to `/var/log/AppleIntelFramebuffer_X_Y` (available in DEBUG binaries).
 - `-igfxfbdump` to dump native and patched framebuffer table to ioreg at IOService:/IOResources/WhateverGreen
-- `igfxcflbklt=1` boot argument (and `enable-cfl-backlight-fix` property) to enable CFL backlight patch
 - `applbkl=0` boot argument (and `applbkl` property) to disable AppleBacklight.kext patches for IGPU. In case of custom AppleBacklight profile- [read here.](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/FAQ.OldPlugins.en.md)
 - `-igfxmlr` boot argument (and `enable-dpcd-max-link-rate-fix` property) to apply the maximum link rate fix.
 - `-igfxhdmidivs` boot argument (and `enable-hdmi-dividers-fix` property) to fix the infinite loop on establishing Intel HDMI connections with a higher pixel clock rate on SKL, KBL and CFL platforms.
@@ -88,6 +87,7 @@ indices of connectors for which online status is enforced. Format is similar to 
 - `igfxrpsc=1` boot argument (`rps-control` property) to enable RPS control patch (improves IGPU performance).
 - `-igfxcdc` boot argument (`enable-cdclk-frequency-fix` property) to support all valid Core Display Clock (CDCLK) frequencies on ICL platforms. [Read the manual](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/FAQ.IntelHD.en.md)
 - `-igfxdvmt` boot argument (`enable-dvmt-calc-fix` property) to fix the kernel panic caused by an incorrectly calculated amount of DVMT pre-allocated memory on Intel ICL platforms.
+- `-igfxblr` boot argument (and `enable-backlight-registers-fix` property) to fix backlight registers on KBL, CFL and ICL platforms.
 
 #### Credits
 

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -422,8 +422,8 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 		//        Submodules that request access to these functions must set `PatchSubmodule::requiresGenericRegisterAccess` to `true`
 		// 	      Also we need to consider the case where multiple submodules want to inject code into these functions.
 		//        At this moment, the backlight fix is the only one that wraps these functions.
-		if (bklCoffeeFb || bklKabyFb ||
-			/*RPSControl.enabled || ForceWakeWorkaround.enabled || */modCoreDisplayClockFix.enabled) {
+		if (bklCoffeeFb || bklKabyFb //||
+			/*RPSControl.enabled || ForceWakeWorkaround.enabled || modCoreDisplayClockFix.enabled*/) {
 			AppleIntelFramebufferController__ReadRegister32 = patcher.solveSymbol<decltype(AppleIntelFramebufferController__ReadRegister32)>
 			(index, "__ZN31AppleIntelFramebufferController14ReadRegister32Em", address, size);
 			if (!AppleIntelFramebufferController__ReadRegister32)
@@ -436,9 +436,6 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 			if (!AppleIntelFramebufferController__WriteRegister32)
 				SYSLOG("igfx", "Failed to find WriteRegister32");
 		}
-		// FIXME: Same issue here.
-		if (/*RPSControl.enabled || ForceWakeWorkaround.enabled || */modDPCDMaxLinkRateFix.enabled)
-			gFramebufferController = patcher.solveSymbol<decltype(gFramebufferController)>(index, "_gController", address, size);
 		if (bklCoffeeFb || bklKabyFb) {
 			// Intel backlight is modeled via pulse-width modulation (PWM). See page 144 of:
 			// https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-kbl-vol12-display.pdf

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -207,6 +207,7 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		
 		disableAccel = checkKernelArgument("-igfxvesa");
 
+		// TODO: DEPRECATED
 		// Enable CFL backlight patch on mobile CFL or if IGPU propery enable-cfl-backlight-fix is set
 		int bkl = 0;
 		if (PE_parse_boot_argn("igfxcflbklt", &bkl, sizeof(bkl)))
@@ -767,10 +768,7 @@ void IGFX::TypeCCheckDisabler::processKernel(KernelPatcher &patcher, DeviceInfo 
 }
 
 void IGFX::TypeCCheckDisabler::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
-	// TODO: Helper Function `getRealFramebuffer()`?
-	auto realFramebuffer = (callbackIGFX->currentFramebuffer && callbackIGFX->currentFramebuffer->loadIndex == index) ? callbackIGFX->currentFramebuffer : callbackIGFX->currentFramebufferOpt;
-	
-	if (realFramebuffer == &kextIntelCFLFb || getKernelVersion() >= KernelVersion::BigSur) {
+	if (callbackIGFX->getRealFramebuffer(index) == &kextIntelCFLFb || getKernelVersion() >= KernelVersion::BigSur) {
 		KernelPatcher::RouteRequest request = {
 			"__ZN31AppleIntelFramebufferController17IsTypeCOnlySystemEv",
 			wrapIsTypeCOnlySystem

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -361,6 +361,15 @@ void IGFX::FramebufferControllerAccessSupport::init() {
 	requiresPatchingFramebuffer = true;
 }
 
+void IGFX::FramebufferControllerAccessSupport::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+	// Enable if at least one active submodule relies on this shared module
+	for (auto submodule : callbackIGFX->submodules)
+		if (submodule->enabled)
+			enabled |= submodule->requiresGlobalFramebufferControllersAccess;
+	
+	DBGLOG("igfx", "FCA: Enabled = %d.", enabled);
+}
+
 void IGFX::FramebufferControllerAccessSupport::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 	KernelPatcher::SolveRequest request("_gController", controllers);
 	if (!patcher.solveMultiple(index, &request, 1, address, size)) {
@@ -385,6 +394,14 @@ void IGFX::MMIORegistersReadSupport::init() {
 void IGFX::MMIORegistersReadSupport::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 	// Enable the verbose output if the boot argument is found
 	verbose = checkKernelArgument("-igfxvamregs");
+	enabled |= verbose;
+	
+	// Enable if at least one active submodule relies on this shared module
+	for (auto submodule : callbackIGFX->submodules)
+		if (submodule->enabled)
+			enabled |= submodule->requiresMMIORegistersReadAccess;
+	
+	DBGLOG("igfx", "RRS: Enabled = %d.", enabled);
 }
 
 void IGFX::MMIORegistersReadSupport::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
@@ -447,6 +464,14 @@ void IGFX::MMIORegistersWriteSupport::init() {
 void IGFX::MMIORegistersWriteSupport::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 	// Enable the verbose output if the boot argument is found
 	verbose = checkKernelArgument("-igfxvamregs");
+	enabled |= verbose;
+	
+	// Enable if at least one active submodule relies on this shared module
+	for (auto submodule : callbackIGFX->submodules)
+		if (submodule->enabled)
+			enabled |= submodule->requiresMMIORegistersWriteAccess;
+	
+	DBGLOG("igfx", "RWS: Enabled = %d.", enabled);
 }
 
 void IGFX::MMIORegistersWriteSupport::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -207,19 +207,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		
 		disableAccel = checkKernelArgument("-igfxvesa");
 
-		// TODO: DEPRECATED
-		// Enable CFL backlight patch on mobile CFL or if IGPU propery enable-cfl-backlight-fix is set
-		int bkl = 0;
-		if (PE_parse_boot_argn("igfxcflbklt", &bkl, sizeof(bkl)))
-			cflBacklightPatch = bkl == 1 ? CoffeeBacklightPatch::On : CoffeeBacklightPatch::Off;
-		else if (info->videoBuiltin->getProperty("enable-cfl-backlight-fix"))
-			cflBacklightPatch = CoffeeBacklightPatch::On;
-		else if (currentFramebuffer == &kextIntelCFLFb && BaseDeviceInfo::get().modelType == WIOKit::ComputerModel::ComputerLaptop)
-			cflBacklightPatch = CoffeeBacklightPatch::Auto;
-
-		if (WIOKit::getOSDataValue(info->videoBuiltin, "max-backlight-freq", targetBacklightFrequency))
-			DBGLOG("igfx", "read custom backlight frequency %u", targetBacklightFrequency);
-
 		bool connectorLessFrame = info->reportedFramebufferIsConnectorLess;
 
 		int gl = info->videoBuiltin->getProperty("disable-metal") != nullptr;
@@ -254,8 +241,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 			if (applyFramebufferPatch || hdmiAutopatch)
 				return true;
 			if (dumpFramebufferToDisk || dumpPlatformTable || debugFramebuffer)
-				return true;
-			if (cflBacklightPatch != CoffeeBacklightPatch::Off)
 				return true;
 			return false;
 		};
@@ -319,82 +304,7 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 
 	if ((currentFramebuffer && currentFramebuffer->loadIndex == index) ||
 		(currentFramebufferOpt && currentFramebufferOpt->loadIndex == index)) {
-		// Find actual framebuffer used (kaby or coffee)
-		auto realFramebuffer = (currentFramebuffer && currentFramebuffer->loadIndex == index) ? currentFramebuffer : currentFramebufferOpt;
-		// Accept Coffee FB and enable backlight patches unless Off (Auto turns them on by default).
-		bool bklCoffeeFb = realFramebuffer == &kextIntelCFLFb && cflBacklightPatch != CoffeeBacklightPatch::Off;
-		// Accept Kaby FB and enable backlight patches if On (Auto is irrelevant here).
-		bool bklKabyFb = realFramebuffer == &kextIntelKBLFb && cflBacklightPatch == CoffeeBacklightPatch::On;
-		// Solve ReadRegister32 just once as it is shared
-		// FIXME: Refactor generic register access as a separate submodule.
-		//        Submodules that request access to these functions must set `PatchSubmodule::requiresGenericRegisterAccess` to `true`
-		// 	      Also we need to consider the case where multiple submodules want to inject code into these functions.
-		//        At this moment, the backlight fix is the only one that wraps these functions.
-		if (bklCoffeeFb || bklKabyFb //||
-			/*RPSControl.enabled || ForceWakeWorkaround.enabled || modCoreDisplayClockFix.enabled*/) {
-			AppleIntelFramebufferController__ReadRegister32 = patcher.solveSymbol<decltype(AppleIntelFramebufferController__ReadRegister32)>
-			(index, "__ZN31AppleIntelFramebufferController14ReadRegister32Em", address, size);
-			if (!AppleIntelFramebufferController__ReadRegister32)
-				SYSLOG("igfx", "Failed to find ReadRegister32");
-		}
-		if (bklCoffeeFb || bklKabyFb //||
-			/*RPSControl.enabled || ForceWakeWorkaround.enabled*/) {
-			AppleIntelFramebufferController__WriteRegister32 = patcher.solveSymbol<decltype(AppleIntelFramebufferController__WriteRegister32)>
-			(index, "__ZN31AppleIntelFramebufferController15WriteRegister32Emj", address, size);
-			if (!AppleIntelFramebufferController__WriteRegister32)
-				SYSLOG("igfx", "Failed to find WriteRegister32");
-		}
-		if (bklCoffeeFb || bklKabyFb) {
-			// Intel backlight is modeled via pulse-width modulation (PWM). See page 144 of:
-			// https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-kbl-vol12-display.pdf
-			// Singal-wise it looks as a cycle of signal levels on the timeline:
-			// 22111100221111002211110022111100 (4 cycles)
-			// 0 - no signal, 1 - no value (no pulse), 2 - pulse (light on)
-			// - Physical Cycle (0+1+2) defines maximum backlight frequency, limited by HW precision.
-			// - Base Cycle (1+2) defines [1/PWM Base Frequency], limited by physical cycle, see BXT_BLC_PWM_FREQ1.
-			// - Duty Cycle (2) defines [1/PWM Increment] - backlight level,
-			//   [PWM Frequency Divider] - backlight max, see BXT_BLC_PWM_DUTY1.
-			// - Duty Cycle position (first vs last) is [PWM Polarity]
-			//
-			// Duty cycle = PWM Base Frequeny * (1 / PWM Increment) / PWM Frequency Divider
-			//
-			// On macOS there are extra limitations:
-			// - All values and operations are u32 (32-bit unsigned)
-			// - [1/PWM Increment] has 0 to 0xFFFF range
-			// - [PWM Frequency Divider] is fixed to be 0xFFFF
-			// - [PWM Base Frequency] is capped by 0xFFFF (to avoid u32 wraparound), and is hardcoded
-			//   either in Framebuffer data (pre-CFL) or in the code (CFL: 7777 or 22222).
-			//
-			// On CFL the following patches have to be applied:
-			// - Hardcoded [PWM Base Frequency] should be patched or set after the hardcoded value is written by patching
-			//   hardcoded frequencies. 65535 is used by default.
-			// - If [PWM Base Frequency] is > 65535, to avoid a wraparound code calculating BXT_BLC_PWM_DUTY1
-			//   should be replaced to use 64-bit arithmetics.
-			// [PWM Base Frequency] can be specified via igfxbklt=1 boot-arg or backlight-base-frequency property.
-
-			// This patch will overwrite WriteRegister32 function to rescale all the register writes of backlight controller.
-			// Slightly different methods are used for CFL hardware running on KBL and CFL drivers.
-
-			if (AppleIntelFramebufferController__ReadRegister32 &&
-				AppleIntelFramebufferController__WriteRegister32) {
-				(bklCoffeeFb ? orgCflReadRegister32 : orgKblReadRegister32) = AppleIntelFramebufferController__ReadRegister32;
-
-				patcher.eraseCoverageInstPrefix(reinterpret_cast<mach_vm_address_t>(AppleIntelFramebufferController__WriteRegister32));
-				auto orgRegWrite = reinterpret_cast<decltype(orgCflWriteRegister32)>
-					(patcher.routeFunction(reinterpret_cast<mach_vm_address_t>(AppleIntelFramebufferController__WriteRegister32), reinterpret_cast<mach_vm_address_t>(bklCoffeeFb ? wrapCflWriteRegister32 : wrapKblWriteRegister32), true));
-
-				if (orgRegWrite) {
-					(bklCoffeeFb ? orgCflWriteRegister32 : orgKblWriteRegister32) = orgRegWrite;
-				} else {
-					SYSLOG("igfx", "failed to route WriteRegister32 for cfl %d", bklCoffeeFb);
-					patcher.clearError();
-				}
-			} else {
-				SYSLOG("igfx", "failed to find ReadRegister32 for cfl %d", bklCoffeeFb);
-				patcher.clearError();
-			}
-		}
-
+		
 		// Iterate through each submodule and redirect the request if and only if the submodule is enabled
 		for (auto submodule : submodules)
 			if (submodule->enabled)
@@ -991,6 +901,183 @@ bool IGFX::ReadDescriptorPatch::globalPageTableRead(void *hardwareGlobalPageTabl
 	return (flags & 3U) != 0;
 }
 
+// MARK: - Backlight Registers Fix
+
+void IGFX::BacklightRegistersFix::init() {
+	// We only need to patch the framebuffer driver
+	requiresPatchingFramebuffer = true;
+	
+	// We need R/W access to MMIO registers
+	requiresMMIORegistersReadAccess = true;
+	requiresMMIORegistersWriteAccess = true;
+}
+
+void IGFX::BacklightRegistersFix::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+	enabled = checkKernelArgument("-igfxblr");
+	if (!enabled)
+		enabled = info->videoBuiltin->getProperty("enable-backlight-registers-fix") != nullptr;
+	if (!enabled)
+		return;
+	
+	if (WIOKit::getOSDataValue(info->videoBuiltin, "max-backlight-freq", targetBacklightFrequency))
+		DBGLOG("igfx", "BLR: Will use the custom backlight frequency %u.", targetBacklightFrequency);
+}
+
+void IGFX::BacklightRegistersFix::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	// Intel backlight is modeled via pulse-width modulation (PWM). See page 144 of:
+	// https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-kbl-vol12-display.pdf
+	// Singal-wise it looks as a cycle of signal levels on the timeline:
+	// 22111100221111002211110022111100 (4 cycles)
+	// 0 - no signal, 1 - no value (no pulse), 2 - pulse (light on)
+	// - Physical Cycle (0+1+2) defines maximum backlight frequency, limited by HW precision.
+	// - Base Cycle (1+2) defines [1/PWM Base Frequency], limited by physical cycle, see BXT_BLC_PWM_FREQ1.
+	// - Duty Cycle (2) defines [1/PWM Increment] - backlight level,
+	//   [PWM Frequency Divider] - backlight max, see BXT_BLC_PWM_DUTY1.
+	// - Duty Cycle position (first vs last) is [PWM Polarity]
+	//
+	// Duty cycle = PWM Base Frequeny * (1 / PWM Increment) / PWM Frequency Divider
+	//
+	// On macOS there are extra limitations:
+	// - All values and operations are u32 (32-bit unsigned)
+	// - [1/PWM Increment] has 0 to 0xFFFF range
+	// - [PWM Frequency Divider] is fixed to be 0xFFFF
+	// - [PWM Base Frequency] is capped by 0xFFFF (to avoid u32 wraparound), and is hardcoded
+	//   either in Framebuffer data (pre-CFL) or in the code (CFL: 7777 or 22222).
+	//
+	// On CFL the following patches have to be applied:
+	// - Hardcoded [PWM Base Frequency] should be patched or set after the hardcoded value is written by patching
+	//   hardcoded frequencies. 65535 is used by default.
+	// - If [PWM Base Frequency] is > 65535, to avoid a wraparound code calculating BXT_BLC_PWM_DUTY1
+	//   should be replaced to use 64-bit arithmetics.
+	// [PWM Base Frequency] can be specified via igfxbklt=1 boot-arg or backlight-base-frequency property.
+
+	// This patch will overwrite WriteRegister32 function to rescale all the register writes of backlight controller.
+	// Slightly different methods are used for CFL hardware running on KBL and CFL drivers.
+	// Guard: Register injections based on the current framebuffer in use
+	if (callbackIGFX->getRealFramebuffer(index) == &kextIntelKBLFb) {
+		DBGLOG("igfx", "BLR: [KBL ] Will setup the fix for KBL platform.");
+		callbackIGFX->modMMIORegistersWriteSupport.replacerList.add(&dKBLPWMFreq1);
+		callbackIGFX->modMMIORegistersWriteSupport.replacerList.add(&dKBLPWMCtrl1);
+	} else {
+		DBGLOG("igfx", "BLR: [CFL+] Will setup the fix for CFL/ICL platform.");
+		callbackIGFX->modMMIORegistersWriteSupport.replacerList.add(&dCFLPWMFreq1);
+		callbackIGFX->modMMIORegistersWriteSupport.replacerList.add(&dCFLPWMDuty1);
+	}
+}
+
+void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMFreq1(void *controller, uint32_t reg, uint32_t value) {
+	DBGLOG("igfx", "BLR: [KBL ] Called with register 0x%x and value 0x%x.", reg, value);
+	assertf(reg == BXT_BLC_PWM_FREQ1, "Fatal Error: Register should be BXT_BLC_PWM_FREQ1.");
+	
+	if (callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency == 0) {
+		// Populate the hardware PWM frequency as initially set up by the system firmware.
+		callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency = callbackIGFX->readRegister32(controller, BXT_BLC_PWM_FREQ1);
+		DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = 0x%x.",
+			   callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
+		DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_CTL1 = 0x%x.",
+			   callbackIGFX->readRegister32(controller, BXT_BLC_PWM_CTL1));
+
+		if (callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency == 0) {
+			// This should not happen with correctly written bootloader code, but in case it does, let's use a failsafe default value.
+			callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency = FallbackTargetBacklightFrequency;
+			SYSLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = ZERO.");
+		}
+	}
+
+	// For the KBL driver, 0xc8254 (BLC_PWM_PCH_CTL2) controls the backlight intensity.
+	// High 16 of this write are the denominator (frequency), low 16 are the numerator (duty cycle).
+	// Translate this into a write to c8258 (BXT_BLC_PWM_DUTY1) for the CFL hardware, scaled by the system-provided value in c8254 (BXT_BLC_PWM_FREQ1).
+	uint16_t frequency = (value & 0xffff0000U) >> 16U;
+	uint16_t dutyCycle = value & 0xffffU;
+
+	uint32_t rescaledValue = frequency == 0 ? 0 : static_cast<uint32_t>((dutyCycle * static_cast<uint64_t>(callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency)) / static_cast<uint64_t>(frequency));
+	DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: Write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x.",
+		   dutyCycle, frequency, rescaledValue, callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
+
+	// Reset the hardware PWM frequency. Write the original system value if the driver-requested value is nonzero. If the driver requests
+	// zero, we allow that, since it's trying to turn off the backlight PWM for sleep.
+	callbackIGFX->writeRegister32(controller, BXT_BLC_PWM_FREQ1, frequency ? callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency : 0);
+
+	// Finish by writing the duty cycle.
+	callbackIGFX->writeRegister32(controller, BXT_BLC_PWM_DUTY1, rescaledValue);
+}
+
+void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMCtrl1(void *controller, uint32_t reg, uint32_t value) {
+	DBGLOG("igfx", "BLR: [KBL ] Called with register 0x%x and value 0x%x.", reg, value);
+	assertf(reg == BXT_BLC_PWM_CTL1, "Fatal Error: Register should be BXT_BLC_PWM_CTL1.");
+	
+	if (callbackIGFX->modBacklightRegistersFix.targetPwmControl == 0) {
+		// Save the original hardware PWM control value
+		callbackIGFX->modBacklightRegistersFix.targetPwmControl = callbackIGFX->readRegister32(controller, BXT_BLC_PWM_CTL1);
+	}
+
+	DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_CTL1>: Write BXT_BLC_PWM_CTL1 0x%x, previous was 0x%x.",
+		   value, callbackIGFX->readRegister32(controller, BXT_BLC_PWM_CTL1));
+
+	if (value) {
+		// Set the PWM frequency before turning it on to avoid the 3 minute blackout bug
+		callbackIGFX->writeRegister32(controller, BXT_BLC_PWM_FREQ1, callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
+
+		// Use the original hardware PWM control value.
+		value = callbackIGFX->modBacklightRegistersFix.targetPwmControl;
+	}
+	
+	// Finish by writing the new value
+	callbackIGFX->writeRegister32(controller, reg, value);
+}
+
+void IGFX::BacklightRegistersFix::wrapCFLWriteRegisterPWMFreq1(void *controller, uint32_t reg, uint32_t value) {
+	DBGLOG("igfx", "BLR: [CFL+] Called with register 0x%x and value 0x%x.", reg, value);
+	assertf(reg == BXT_BLC_PWM_FREQ1, "Fatal Error: Register should be BXT_BLC_PWM_FREQ1.");
+	
+	if (value && value != callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency) {
+		DBGLOG("igfx", "BRL: [CFL+] WriteRegister32<BXT_BLC_PWM_FREQ1>: Driver requested BXT_BLC_PWM_FREQ1 = 0x%x.", value);
+		callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency = value;
+	}
+
+	if (callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency == 0) {
+		// Save the hardware PWM frequency as initially set up by the system firmware.
+		// We'll need this to restore later after system sleep.
+		callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency = callbackIGFX->readRegister32(controller, BXT_BLC_PWM_FREQ1);
+		DBGLOG("igfx", "BRL: [CFL+] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = 0x%x.", callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
+
+		if (callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency == 0) {
+			// This should not happen with correctly written bootloader code, but in case it does, let's use a failsafe default value.
+			callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency = FallbackTargetBacklightFrequency;
+			SYSLOG("igfx", "BRL: [CFL+] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = ZERO.");
+		}
+	}
+
+	if (value) {
+		// Nonzero writes to this register need to use the original system value.
+		// Yet the driver can safely write zero to this register as part of system sleep.
+		value = callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency;
+	}
+	
+	// Finish by writing the new value
+	callbackIGFX->writeRegister32(controller, reg, value);
+}
+
+void IGFX::BacklightRegistersFix::wrapCFLWriteRegisterPWMDuty1(void *controller, uint32_t reg, uint32_t value) {
+	DBGLOG("igfx", "BLR: [CFL+] Called with register 0x%x and value 0x%x.", reg, value);
+	assertf(reg == BXT_BLC_PWM_DUTY1, "Fatal Error: Register should be BXT_BLC_PWM_DUTY1.");
+	
+	if (callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency && callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency) {
+		// Translate the PWM duty cycle between the driver scale value and the HW scale value
+		uint32_t rescaledValue = static_cast<uint32_t>((value * static_cast<uint64_t>(callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency)) / static_cast<uint64_t>(callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency));
+		DBGLOG("igfx", "BRL: WriteRegister32<BXT_BLC_PWM_DUTY1>: Write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x.", value,
+			   callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency, rescaledValue, callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
+		value = rescaledValue;
+	} else {
+		// This should never happen, but in case it does we should log it at the very least.
+		SYSLOG("igfx", "BRL: WriteRegister32<BXT_BLC_PWM_DUTY1>: Write PWM_DUTY1 has zero frequency driver (%d) target (%d).",
+			   callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency, callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
+	}
+	
+	// Finish by writing the new value
+	callbackIGFX->writeRegister32(controller, reg, value);
+}
+
 // MARK: - TODO
 
 OSObject *IGFX::wrapCopyExistingServices(OSDictionary *matching, IOOptionBits inState, IOOptionBits options) {
@@ -1098,102 +1185,6 @@ bool IGFX::wrapAcceleratorStart(IOService *that, IOService *provider) {
 	}
 
 	return ret;
-}
-
-void IGFX::wrapCflWriteRegister32(void *that, uint32_t reg, uint32_t value) {
-	if (reg == BXT_BLC_PWM_FREQ1) {
-		if (value && value != callbackIGFX->driverBacklightFrequency) {
-			DBGLOG("igfx", "wrapCflWriteRegister32: driver requested BXT_BLC_PWM_FREQ1 = 0x%x", value);
-			callbackIGFX->driverBacklightFrequency = value;
-		}
-
-		if (callbackIGFX->targetBacklightFrequency == 0) {
-			// Save the hardware PWM frequency as initially set up by the system firmware.
-			// We'll need this to restore later after system sleep.
-			callbackIGFX->targetBacklightFrequency = callbackIGFX->orgCflReadRegister32(that, BXT_BLC_PWM_FREQ1);
-			DBGLOG("igfx", "wrapCflWriteRegister32: system initialized BXT_BLC_PWM_FREQ1 = 0x%x", callbackIGFX->targetBacklightFrequency);
-
-			if (callbackIGFX->targetBacklightFrequency == 0) {
-				// This should not happen with correctly written bootloader code, but in case it does, let's use a failsafe default value.
-				callbackIGFX->targetBacklightFrequency = FallbackTargetBacklightFrequency;
-				SYSLOG("igfx", "wrapCflWriteRegister32: system initialized BXT_BLC_PWM_FREQ1 is ZERO");
-			}
-		}
-
-		if (value) {
-			// Nonzero writes to this register need to use the original system value.
-			// Yet the driver can safely write zero to this register as part of system sleep.
-			value = callbackIGFX->targetBacklightFrequency;
-		}
-	} else if (reg == BXT_BLC_PWM_DUTY1) {
-		if (callbackIGFX->driverBacklightFrequency && callbackIGFX->targetBacklightFrequency) {
-			// Translate the PWM duty cycle between the driver scale value and the HW scale value
-			uint32_t rescaledValue = static_cast<uint32_t>((value * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
-				static_cast<uint64_t>(callbackIGFX->driverBacklightFrequency));
-			DBGLOG("igfx", "wrapCflWriteRegister32: write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x", value,
-				   callbackIGFX->driverBacklightFrequency, rescaledValue, callbackIGFX->targetBacklightFrequency);
-			value = rescaledValue;
-		} else {
-			// This should never happen, but in case it does we should log it at the very least.
-			SYSLOG("igfx", "wrapCflWriteRegister32: write PWM_DUTY1 has zero frequency driver (%d) target (%d)",
-				   callbackIGFX->driverBacklightFrequency, callbackIGFX->targetBacklightFrequency);
-		}
-	}
-
-	callbackIGFX->orgCflWriteRegister32(that, reg, value);
-}
-
-void IGFX::wrapKblWriteRegister32(void *that, uint32_t reg, uint32_t value) {
-	if (reg == BXT_BLC_PWM_FREQ1) { // aka BLC_PWM_PCH_CTL2
-		if (callbackIGFX->targetBacklightFrequency == 0) {
-			// Populate the hardware PWM frequency as initially set up by the system firmware.
-			callbackIGFX->targetBacklightFrequency = callbackIGFX->orgKblReadRegister32(that, BXT_BLC_PWM_FREQ1);
-			DBGLOG("igfx", "wrapKblWriteRegister32: system initialized BXT_BLC_PWM_FREQ1 = 0x%x", callbackIGFX->targetBacklightFrequency);
-			DBGLOG("igfx", "wrapKblWriteRegister32: system initialized BXT_BLC_PWM_CTL1 = 0x%x", callbackIGFX->orgKblReadRegister32(that, BXT_BLC_PWM_CTL1));
-
-			if (callbackIGFX->targetBacklightFrequency == 0) {
-				// This should not happen with correctly written bootloader code, but in case it does, let's use a failsafe default value.
-				callbackIGFX->targetBacklightFrequency = FallbackTargetBacklightFrequency;
-				SYSLOG("igfx", "wrapKblWriteRegister32: system initialized BXT_BLC_PWM_FREQ1 is ZERO");
-			}
-		}
-
-		// For the KBL driver, 0xc8254 (BLC_PWM_PCH_CTL2) controls the backlight intensity.
-		// High 16 of this write are the denominator (frequency), low 16 are the numerator (duty cycle).
-		// Translate this into a write to c8258 (BXT_BLC_PWM_DUTY1) for the CFL hardware, scaled by the system-provided value in c8254 (BXT_BLC_PWM_FREQ1).
-		uint16_t frequency = (value & 0xffff0000U) >> 16U;
-		uint16_t dutyCycle = value & 0xffffU;
-
-		uint32_t rescaledValue = frequency == 0 ? 0 : static_cast<uint32_t>((dutyCycle * static_cast<uint64_t>(callbackIGFX->targetBacklightFrequency)) /
-										    static_cast<uint64_t>(frequency));
-		DBGLOG("igfx", "wrapKblWriteRegister32: write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x",
-			   dutyCycle, frequency, rescaledValue, callbackIGFX->targetBacklightFrequency);
-
-		// Reset the hardware PWM frequency. Write the original system value if the driver-requested value is nonzero. If the driver requests
-		// zero, we allow that, since it's trying to turn off the backlight PWM for sleep.
-		callbackIGFX->orgKblWriteRegister32(that, BXT_BLC_PWM_FREQ1, frequency ? callbackIGFX->targetBacklightFrequency : 0);
-
-		// Finish by writing the duty cycle.
-		reg = BXT_BLC_PWM_DUTY1;
-		value = rescaledValue;
-	} else if (reg == BXT_BLC_PWM_CTL1) {
-		if (callbackIGFX->targetPwmControl == 0) {
-			// Save the original hardware PWM control value
-			callbackIGFX->targetPwmControl = callbackIGFX->orgKblReadRegister32(that, BXT_BLC_PWM_CTL1);
-		}
-
-		DBGLOG("igfx", "wrapKblWriteRegister32: write BXT_BLC_PWM_CTL1 0x%x, previous was 0x%x", value, callbackIGFX->orgKblReadRegister32(that, BXT_BLC_PWM_CTL1));
-
-		if (value) {
-			// Set the PWM frequency before turning it on to avoid the 3 minute blackout bug
-			callbackIGFX->orgKblWriteRegister32(that, BXT_BLC_PWM_FREQ1, callbackIGFX->targetBacklightFrequency);
-
-			// Use the original hardware PWM control value.
-			value = callbackIGFX->targetPwmControl;
-		}
-	}
-
-	callbackIGFX->orgKblWriteRegister32(that, reg, value);
 }
 
 bool IGFX::wrapGetOSInformation(IOService *that) {

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -1002,7 +1002,7 @@ void IGFX::BacklightRegistersFix::processFramebufferKext(KernelPatcher &patcher,
 	// Slightly different methods are used for CFL hardware running on KBL and CFL drivers.
 	// Guard: Register injections based on the current framebuffer in use
 	if (callbackIGFX->getRealFramebuffer(index) == &kextIntelKBLFb) {
-		DBGLOG("igfx", "BLR: [KBL ] Will setup the fix for KBL platform.");
+		DBGLOG("igfx", "BLR: [KBL*] Will setup the fix for KBL platform.");
 		callbackIGFX->modMMIORegistersWriteSupport.replacerList.add(&dKBLPWMFreq1);
 		callbackIGFX->modMMIORegistersWriteSupport.replacerList.add(&dKBLPWMCtrl1);
 	} else {
@@ -1013,21 +1013,21 @@ void IGFX::BacklightRegistersFix::processFramebufferKext(KernelPatcher &patcher,
 }
 
 void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMFreq1(void *controller, uint32_t reg, uint32_t value) {
-	DBGLOG("igfx", "BLR: [KBL ] Called with register 0x%x and value 0x%x.", reg, value);
+	DBGLOG("igfx", "BLR: [KBL*] WriteRegister32<BXT_BLC_PWM_FREQ1>: Called with register 0x%x and value 0x%x.", reg, value);
 	assertf(reg == BXT_BLC_PWM_FREQ1, "Fatal Error: Register should be BXT_BLC_PWM_FREQ1.");
 	
 	if (callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency == 0) {
 		// Populate the hardware PWM frequency as initially set up by the system firmware.
 		callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency = callbackIGFX->readRegister32(controller, BXT_BLC_PWM_FREQ1);
-		DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = 0x%x.",
+		DBGLOG("igfx", "BLR: [KBL*] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = 0x%x.",
 			   callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
-		DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_CTL1 = 0x%x.",
+		DBGLOG("igfx", "BLR: [KBL*] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_CTL1 = 0x%x.",
 			   callbackIGFX->readRegister32(controller, BXT_BLC_PWM_CTL1));
 
 		if (callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency == 0) {
 			// This should not happen with correctly written bootloader code, but in case it does, let's use a failsafe default value.
 			callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency = FallbackTargetBacklightFrequency;
-			SYSLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = ZERO.");
+			SYSLOG("igfx", "BLR: [KBL*] WriteRegister32<BXT_BLC_PWM_FREQ1>: System initialized with BXT_BLC_PWM_FREQ1 = ZERO.");
 		}
 	}
 
@@ -1038,7 +1038,7 @@ void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMFreq1(void *controller,
 	uint16_t dutyCycle = value & 0xffffU;
 
 	uint32_t rescaledValue = frequency == 0 ? 0 : static_cast<uint32_t>((dutyCycle * static_cast<uint64_t>(callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency)) / static_cast<uint64_t>(frequency));
-	DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_FREQ1>: Write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x.",
+	DBGLOG("igfx", "BLR: [KBL*] WriteRegister32<BXT_BLC_PWM_FREQ1>: Write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x.",
 		   dutyCycle, frequency, rescaledValue, callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
 
 	// Reset the hardware PWM frequency. Write the original system value if the driver-requested value is nonzero. If the driver requests
@@ -1050,7 +1050,7 @@ void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMFreq1(void *controller,
 }
 
 void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMCtrl1(void *controller, uint32_t reg, uint32_t value) {
-	DBGLOG("igfx", "BLR: [KBL ] Called with register 0x%x and value 0x%x.", reg, value);
+	DBGLOG("igfx", "BLR: [KBL*] WriteRegister32<BXT_BLC_PWM_CTL1>: Called with register 0x%x and value 0x%x.", reg, value);
 	assertf(reg == BXT_BLC_PWM_CTL1, "Fatal Error: Register should be BXT_BLC_PWM_CTL1.");
 	
 	if (callbackIGFX->modBacklightRegistersFix.targetPwmControl == 0) {
@@ -1058,7 +1058,7 @@ void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMCtrl1(void *controller,
 		callbackIGFX->modBacklightRegistersFix.targetPwmControl = callbackIGFX->readRegister32(controller, BXT_BLC_PWM_CTL1);
 	}
 
-	DBGLOG("igfx", "BLR: [KBL ] WriteRegister32<BXT_BLC_PWM_CTL1>: Write BXT_BLC_PWM_CTL1 0x%x, previous was 0x%x.",
+	DBGLOG("igfx", "BLR: [KBL*] WriteRegister32<BXT_BLC_PWM_CTL1>: Write BXT_BLC_PWM_CTL1 0x%x, previous was 0x%x.",
 		   value, callbackIGFX->readRegister32(controller, BXT_BLC_PWM_CTL1));
 
 	if (value) {
@@ -1074,7 +1074,7 @@ void IGFX::BacklightRegistersFix::wrapKBLWriteRegisterPWMCtrl1(void *controller,
 }
 
 void IGFX::BacklightRegistersFix::wrapCFLWriteRegisterPWMFreq1(void *controller, uint32_t reg, uint32_t value) {
-	DBGLOG("igfx", "BLR: [CFL+] Called with register 0x%x and value 0x%x.", reg, value);
+	DBGLOG("igfx", "BLR: [CFL+] WriteRegister32<BXT_BLC_PWM_FREQ1>: Called with register 0x%x and value 0x%x.", reg, value);
 	assertf(reg == BXT_BLC_PWM_FREQ1, "Fatal Error: Register should be BXT_BLC_PWM_FREQ1.");
 	
 	if (value && value != callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency) {
@@ -1106,18 +1106,18 @@ void IGFX::BacklightRegistersFix::wrapCFLWriteRegisterPWMFreq1(void *controller,
 }
 
 void IGFX::BacklightRegistersFix::wrapCFLWriteRegisterPWMDuty1(void *controller, uint32_t reg, uint32_t value) {
-	DBGLOG("igfx", "BLR: [CFL+] Called with register 0x%x and value 0x%x.", reg, value);
+	DBGLOG("igfx", "BLR: [CFL+] WriteRegister32<BXT_BLC_PWM_DUTY1>: Called with register 0x%x and value 0x%x.", reg, value);
 	assertf(reg == BXT_BLC_PWM_DUTY1, "Fatal Error: Register should be BXT_BLC_PWM_DUTY1.");
 	
 	if (callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency && callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency) {
 		// Translate the PWM duty cycle between the driver scale value and the HW scale value
 		uint32_t rescaledValue = static_cast<uint32_t>((value * static_cast<uint64_t>(callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency)) / static_cast<uint64_t>(callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency));
-		DBGLOG("igfx", "BRL: WriteRegister32<BXT_BLC_PWM_DUTY1>: Write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x.", value,
+		DBGLOG("igfx", "BRL: [CFL+] WriteRegister32<BXT_BLC_PWM_DUTY1>: Write PWM_DUTY1 0x%x/0x%x, rescaled to 0x%x/0x%x.", value,
 			   callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency, rescaledValue, callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
 		value = rescaledValue;
 	} else {
 		// This should never happen, but in case it does we should log it at the very least.
-		SYSLOG("igfx", "BRL: WriteRegister32<BXT_BLC_PWM_DUTY1>: Write PWM_DUTY1 has zero frequency driver (%d) target (%d).",
+		SYSLOG("igfx", "BRL: [CFL+] WriteRegister32<BXT_BLC_PWM_DUTY1>: Write PWM_DUTY1 has zero frequency driver (%d) target (%d).",
 			   callbackIGFX->modBacklightRegistersFix.driverBacklightFrequency, callbackIGFX->modBacklightRegistersFix.targetBacklightFrequency);
 	}
 	

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -607,6 +607,18 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 	return false;
 }
 
+void IGFX::FramebufferControllerAccessSupport::init() {
+	// We only need to patch the framebuffer driver
+	requiresPatchingGraphics = false;
+	requiresPatchingFramebuffer = true;
+}
+
+void IGFX::FramebufferControllerAccessSupport::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	KernelPatcher::SolveRequest request("_gController", controllers);
+	if (!patcher.solveMultiple(index, &request, 1, address, size))
+		SYSLOG("igfx", "FCA: Failed to resolve the symbol of global controllers.");
+}
+
 IOReturn IGFX::wrapPavpSessionCallback(void *intelAccelerator, int32_t sessionCommand, uint32_t sessionAppId, uint32_t *a4, bool flag) {
 	//DBGLOG("igfx, "pavpCallback: cmd = %d, flag = %d, app = %u, a4 = %s", sessionCommand, flag, sessionAppId, a4 == nullptr ? "null" : "not null");
 

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -189,7 +189,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 #ifdef DEBUG
 		dumpFramebufferToDisk = checkKernelArgument("-igfxdump");
 		dumpPlatformTable = checkKernelArgument("-igfxfbdump");
-		debugFramebuffer = checkKernelArgument("-igfxfbdbg");
 #endif
 
 		if (supportsGuCFirmware && getKernelVersion() >= KernelVersion::HighSierra) {
@@ -240,7 +239,7 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		auto requiresFramebufferPatches = [this]() {
 			if (applyFramebufferPatch || hdmiAutopatch)
 				return true;
-			if (dumpFramebufferToDisk || dumpPlatformTable || debugFramebuffer)
+			if (dumpFramebufferToDisk || dumpPlatformTable)
 				return true;
 			return false;
 		};
@@ -309,9 +308,6 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 		for (auto submodule : submodules)
 			if (submodule->enabled)
 				submodule->processFramebufferKext(patcher, index, address, size);
-
-		if (debugFramebuffer)
-			loadFramebufferDebug(patcher, index, address, size);
 
 		if (applyFramebufferPatch || dumpFramebufferToDisk || dumpPlatformTable || hdmiAutopatch) {
 			framebufferStart = reinterpret_cast<uint8_t *>(address);

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -102,7 +102,7 @@ void IGFX::init() {
 			currentGraphics = &kextIntelSKL;
 			currentFramebuffer = &kextIntelSKLFb;
 			modForceCompleteModeset.supported = modForceCompleteModeset.legacy = true; // not enabled, as on legacy operating systems it casues crashes.
-			disableTypeCCheck = getKernelVersion() >= KernelVersion::BigSur;
+			modTypeCCheckDisabler.enabled = getKernelVersion() >= KernelVersion::BigSur;
 			break;
 		case CPUInfo::CpuGeneration::KabyLake:
 			supportsGuCFirmware = true;
@@ -111,7 +111,7 @@ void IGFX::init() {
 			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			modRPSControlPatch.available = true;
 			modForceWakeWorkaround.enabled = true;
-			disableTypeCCheck = getKernelVersion() >= KernelVersion::BigSur;
+			modTypeCCheckDisabler.enabled = getKernelVersion() >= KernelVersion::BigSur;
 			break;
 		case CPUInfo::CpuGeneration::CoffeeLake:
 			supportsGuCFirmware = true;
@@ -125,14 +125,14 @@ void IGFX::init() {
 			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			modRPSControlPatch.available = true;
 			modForceWakeWorkaround.enabled = true;
-			disableTypeCCheck = true;
+			modTypeCCheckDisabler.enabled = true;
 			break;
 		case CPUInfo::CpuGeneration::CannonLake:
 			supportsGuCFirmware = true;
 			currentGraphics = &kextIntelCNL;
 			currentFramebuffer = &kextIntelCNLFb;
 			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
-			disableTypeCCheck = true;
+			modTypeCCheckDisabler.enabled = true;
 			break;
 		case CPUInfo::CpuGeneration::IceLake:
 			supportsGuCFirmware = true;
@@ -153,7 +153,7 @@ void IGFX::init() {
 			// See: https://github.com/torvalds/linux/blob/135c5504a600ff9b06e321694fbcac78a9530cd4/drivers/gpu/drm/i915/intel_mocs.c#L181
 			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			modRPSControlPatch.available = true;
-			disableTypeCCheck = true;
+			modTypeCCheckDisabler.enabled = true;
 			break;
 		default:
 			SYSLOG("igfx", "found an unsupported processor 0x%X:0x%X, please report this!", family, model);
@@ -206,8 +206,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 			submodule->processKernel(patcher, info);
 		
 		disableAccel = checkKernelArgument("-igfxvesa");
-		
-		disableTypeCCheck &= !checkKernelArgument("-igfxtypec");
 
 		// Enable CFL backlight patch on mobile CFL or if IGPU propery enable-cfl-backlight-fix is set
 		int bkl = 0;
@@ -223,6 +221,7 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 
 		bool connectorLessFrame = info->reportedFramebufferIsConnectorLess;
 
+		// TODO:DEPRECATED
 		// Black screen (ComputeLaneCount) happened from 10.12.4
 		// It only affects SKL, KBL, and CFL drivers with a frame with connectors.
 		if (!connectorLessFrame && cpuGeneration >= CPUInfo::CpuGeneration::Skylake &&
@@ -275,8 +274,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 			if (dumpFramebufferToDisk || dumpPlatformTable || debugFramebuffer)
 				return true;
 			if (cflBacklightPatch != CoffeeBacklightPatch::Off)
-				return true;
-			if (disableTypeCCheck)
 				return true;
 			return false;
 		};
@@ -440,18 +437,11 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 		for (auto submodule : submodules)
 			if (submodule->enabled)
 				submodule->processFramebufferKext(patcher, index, address, size);
-		
-		// TODO: PORT
-		if (disableTypeCCheck && (realFramebuffer == &kextIntelCFLFb || getKernelVersion() >= KernelVersion::BigSur)) {
-			KernelPatcher::RouteRequest req("__ZN31AppleIntelFramebufferController17IsTypeCOnlySystemEv", wrapIsTypeCOnlySystem);
-			if (!patcher.routeMultiple(index, &req, 1, address, size))
-				SYSLOG("igfx", "failed to route IsTypeCOnlySystem");
-		}
 
 		if (debugFramebuffer)
 			loadFramebufferDebug(patcher, index, address, size);
 
-		// TODO: PORT
+		// TODO: DEPRECATED
 		if (blackScreenPatch) {
 			bool foundSymbol = false;
 
@@ -820,6 +810,36 @@ IOReturn IGFX::AGDCDisabler::wrapFBClientDoAttribute(void *fbclient, uint32_t at
 	return callbackIGFX->modAGDCDisabler.orgFBClientDoAttribute(fbclient, attribute, unk1, unk2, unk3, unk4, externalMethodArguments);
 }
 
+// MARK: - Type-C Check Disabler
+
+void IGFX::TypeCCheckDisabler::init() {
+	// We only need to patch the framebuffer driver
+	requiresPatchingFramebuffer = true;
+}
+
+void IGFX::TypeCCheckDisabler::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+	enabled &= !checkKernelArgument("-igfxtypec");
+}
+
+void IGFX::TypeCCheckDisabler::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	// TODO: Helper Function `getRealFramebuffer()`?
+	auto realFramebuffer = (callbackIGFX->currentFramebuffer && callbackIGFX->currentFramebuffer->loadIndex == index) ? callbackIGFX->currentFramebuffer : callbackIGFX->currentFramebufferOpt;
+	
+	if (realFramebuffer == &kextIntelCFLFb || getKernelVersion() >= KernelVersion::BigSur) {
+		KernelPatcher::RouteRequest request = {
+			"__ZN31AppleIntelFramebufferController17IsTypeCOnlySystemEv",
+			wrapIsTypeCOnlySystem
+		};
+		if (!patcher.routeMultiple(index, &request, 1, address, size))
+			SYSLOG("igfx", "TCCD: Failed to route the function IsTypeCOnlySystem.");
+	}
+}
+
+bool IGFX::TypeCCheckDisabler::wrapIsTypeCOnlySystem(void *controller) {
+	DBGLOG("igfx", "TCCD: Forcing IsTypeCOnlySystem false.");
+	return false;
+}
+
 // MARK: - TODO
 
 IOReturn IGFX::wrapPavpSessionCallback(void *intelAccelerator, int32_t sessionCommand, uint32_t sessionAppId, uint32_t *a4, bool flag) {
@@ -887,6 +907,7 @@ bool IGFX::globalPageTableRead(void *hardwareGlobalPageTable, uint64_t address, 
 	return (flags & 3U) != 0;
 }
 
+// TODO: DEPRECATED
 bool IGFX::wrapComputeLaneCount(void *that, void *timing, uint32_t bpp, int32_t availableLanes, int32_t *laneCount) {
 	DBGLOG("igfx", "computeLaneCount: bpp = %u, available = %d", bpp, availableLanes);
 
@@ -913,6 +934,7 @@ bool IGFX::wrapComputeLaneCount(void *that, void *timing, uint32_t bpp, int32_t 
 	return r;
 }
 
+// TODO: DEPRECATED
 bool IGFX::wrapComputeLaneCountNouveau(void *that, void *timing, int32_t availableLanes, int32_t *laneCount) {
 	bool r = FunctionCast(wrapComputeLaneCountNouveau, callbackIGFX->orgComputeLaneCount)(that, timing, availableLanes, laneCount);
 	if (!r && *laneCount == 0) {
@@ -1036,6 +1058,7 @@ bool IGFX::wrapAcceleratorStart(IOService *that, IOService *provider) {
  * This breaks many systems, so we undo this check.
  * Affected drivers: KBL and newer?
  */
+// TODO: DEPRECATED
 uint64_t IGFX::wrapIsTypeCOnlySystem(void*) {
 	DBGLOG("igfx", "Forcing IsTypeCOnlySystem 0");
 	return 0;

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -101,14 +101,14 @@ void IGFX::init() {
 			supportsGuCFirmware = true;
 			currentGraphics = &kextIntelSKL;
 			currentFramebuffer = &kextIntelSKLFb;
-			forceCompleteModeset.supported = forceCompleteModeset.legacy = true; // not enabled, as on legacy operating systems it casues crashes.
+			modForceCompleteModeset.supported = modForceCompleteModeset.legacy = true; // not enabled, as on legacy operating systems it casues crashes.
 			disableTypeCCheck = getKernelVersion() >= KernelVersion::BigSur;
 			break;
 		case CPUInfo::CpuGeneration::KabyLake:
 			supportsGuCFirmware = true;
 			currentGraphics = &kextIntelKBL;
 			currentFramebuffer = &kextIntelKBLFb;
-			forceCompleteModeset.supported = forceCompleteModeset.enable = true;
+			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			modRPSControlPatch.available = true;
 			modForceWakeWorkaround.enabled = true;
 			disableTypeCCheck = getKernelVersion() >= KernelVersion::BigSur;
@@ -122,7 +122,7 @@ void IGFX::init() {
 			// Note, several CFL GPUs are completely broken. They freeze in IGMemoryManager::initCache due to incompatible
 			// configuration, supposedly due to Apple not supporting new MOCS table and forcing Skylake-based format.
 			// See: https://github.com/torvalds/linux/blob/135c5504a600ff9b06e321694fbcac78a9530cd4/drivers/gpu/drm/i915/intel_mocs.c#L181
-			forceCompleteModeset.supported = forceCompleteModeset.enable = true;
+			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			modRPSControlPatch.available = true;
 			modForceWakeWorkaround.enabled = true;
 			disableTypeCCheck = true;
@@ -131,7 +131,7 @@ void IGFX::init() {
 			supportsGuCFirmware = true;
 			currentGraphics = &kextIntelCNL;
 			currentFramebuffer = &kextIntelCNLFb;
-			forceCompleteModeset.supported = forceCompleteModeset.enable = true;
+			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			disableTypeCCheck = true;
 			break;
 		case CPUInfo::CpuGeneration::IceLake:
@@ -139,7 +139,7 @@ void IGFX::init() {
 			currentGraphics = &kextIntelICL;
 			currentFramebuffer = &kextIntelICLLPFb;
 			currentFramebufferOpt = &kextIntelICLHPFb;
-			forceCompleteModeset.supported = forceCompleteModeset.enable = true;
+			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			modDVMTCalcFix.available = true;
 			break;
 		case CPUInfo::CpuGeneration::CometLake:
@@ -151,7 +151,7 @@ void IGFX::init() {
 			// Note, several CFL GPUs are completely broken. They freeze in IGMemoryManager::initCache due to incompatible
 			// configuration, supposedly due to Apple not supporting new MOCS table and forcing Skylake-based format.
 			// See: https://github.com/torvalds/linux/blob/135c5504a600ff9b06e321694fbcac78a9530cd4/drivers/gpu/drm/i915/intel_mocs.c#L181
-			forceCompleteModeset.supported = forceCompleteModeset.enable = true;
+			modForceCompleteModeset.supported = modForceCompleteModeset.enabled = true;
 			modRPSControlPatch.available = true;
 			disableTypeCCheck = true;
 			break;
@@ -191,47 +191,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		dumpPlatformTable = checkKernelArgument("-igfxfbdump");
 		debugFramebuffer = checkKernelArgument("-igfxfbdbg");
 #endif
-
-		uint32_t forceCompleteModeSet = 0;
-		if (PE_parse_boot_argn("igfxfcms", &forceCompleteModeSet, sizeof(forceCompleteModeSet))) {
-			forceCompleteModeset.enable = forceCompleteModeset.supported && forceCompleteModeSet != 0;
-			DBGLOG("weg", "force complete-modeset overriden by boot-argument %u -> %d", forceCompleteModeSet, forceCompleteModeset.enable);
-		} else if (WIOKit::getOSDataValue(info->videoBuiltin, "complete-modeset", forceCompleteModeSet)) {
-			forceCompleteModeset.enable = forceCompleteModeset.supported && forceCompleteModeSet != 0;
-			DBGLOG("weg", "force complete-modeset overriden by device property %u -> %d", forceCompleteModeSet, forceCompleteModeset.enable);
-		} else if (info->firmwareVendor == DeviceInfo::FirmwareVendor::Apple) {
-			forceCompleteModeset.enable = false; // may interfere with FV2
-			DBGLOG("weg", "force complete-modeset overriden by Apple firmware -> %d", forceCompleteModeset.enable);
-		}
-
-		if (forceCompleteModeset.enable) {
-			uint64_t fbs;
-			if (PE_parse_boot_argn("igfxfcmsfbs", &fbs, sizeof(fbs)) ||
-				WIOKit::getOSDataValue(info->videoBuiltin, "complete-modeset-framebuffers", fbs)) {
-				for (size_t i = 0; i < arrsize(forceCompleteModeset.fbs); i++)
-					forceCompleteModeset.fbs[i] = (fbs >> (8 * i)) & 0xffU;
-				forceCompleteModeset.customised = true;
-			}
-		}
-
-		uint32_t forceOnline = 0;
-		if (PE_parse_boot_argn("igfxonln", &forceOnline, sizeof(forceOnline))) {
-			forceOnlineDisplay.enable = forceOnline != 0;
-			DBGLOG("weg", "force online overriden by boot-argument %u", forceOnline);
-		} else if (WIOKit::getOSDataValue(info->videoBuiltin, "force-online", forceOnline)) {
-			forceOnlineDisplay.enable = forceOnline != 0;
-			DBGLOG("weg", "force online overriden by device property %u", forceOnline);
-		}
-
-		if (forceOnlineDisplay.enable) {
-			uint64_t fbs;
-			if (PE_parse_boot_argn("igfxonlnfbs", &fbs, sizeof(fbs)) ||
-				WIOKit::getOSDataValue(info->videoBuiltin, "force-online-framebuffers", fbs)) {
-				for (size_t i = 0; i < arrsize(forceOnlineDisplay.fbs); i++)
-					forceOnlineDisplay.fbs[i] = (fbs >> (8 * i)) & 0xffU;
-				forceOnlineDisplay.customised = true;
-			}
-		}
 
 		if (supportsGuCFirmware && getKernelVersion() >= KernelVersion::HighSierra) {
 			if (!PE_parse_boot_argn("igfxfw", &fwLoadMode, sizeof(fwLoadMode)))
@@ -320,10 +279,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 			if (dumpFramebufferToDisk || dumpPlatformTable || debugFramebuffer)
 				return true;
 			if (cflBacklightPatch != CoffeeBacklightPatch::Off)
-				return true;
-			if (forceCompleteModeset.enable)
-				return true;
-			if (forceOnlineDisplay.enable)
 				return true;
 			if (disableAGDC)
 				return true;
@@ -491,21 +446,6 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 		for (auto submodule : submodules)
 			if (submodule->enabled)
 				submodule->processFramebufferKext(patcher, index, address, size);
-		
-		if (forceCompleteModeset.enable) {
-			const char *sym = "__ZN31AppleIntelFramebufferController16hwRegsNeedUpdateEP21AppleIntelFramebufferP21AppleIntelDisplayPathPNS_10CRTCParamsEPK29IODetailedTimingInformationV2";
-			if (forceCompleteModeset.legacy)
-				sym = "__ZN31AppleIntelFramebufferController16hwRegsNeedUpdateEP21AppleIntelFramebufferP21AppleIntelDisplayPathPNS_10CRTCParamsE";
-			KernelPatcher::RouteRequest request(sym, wrapHwRegsNeedUpdate, orgHwRegsNeedUpdate);
-			if (!patcher.routeMultiple(index, &request, 1, address, size))
-				SYSLOG("igfx", "failed to route hwRegsNeedUpdate");
-		}
-
-		if (forceOnlineDisplay.enable) {
-			KernelPatcher::RouteRequest request("__ZN21AppleIntelFramebuffer16getDisplayStatusEP21AppleIntelDisplayPath", wrapGetDisplayStatus, orgGetDisplayStatus);
-			if (!patcher.routeMultiple(index, &request, 1, address, size))
-				SYSLOG("igfx", "failed to route getDisplayStatus");
-		}
 		
 		if (disableTypeCCheck && (realFramebuffer == &kextIntelCFLFb || getKernelVersion() >= KernelVersion::BigSur)) {
 			KernelPatcher::RouteRequest req("__ZN31AppleIntelFramebufferController17IsTypeCOnlySystemEv", wrapIsTypeCOnlySystem);
@@ -724,6 +664,141 @@ void IGFX::MMIORegistersWriteSupport::wrapWriteRegister32(void *controller, uint
 	}
 }
 
+// MARK: - Force Complete Modeset
+
+void IGFX::ForceCompleteModeset::init() {
+	// We only need to patch the framebuffer driver
+	requiresPatchingFramebuffer = true;
+}
+
+void IGFX::ForceCompleteModeset::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+	uint32_t forceCompleteModeSet = 0;
+	if (PE_parse_boot_argn("igfxfcms", &forceCompleteModeSet, sizeof(forceCompleteModeSet))) {
+		enabled = supported && forceCompleteModeSet != 0;
+		DBGLOG("weg", "force complete-modeset overriden by boot-argument %u -> %d", forceCompleteModeSet, enabled);
+	} else if (WIOKit::getOSDataValue(info->videoBuiltin, "complete-modeset", forceCompleteModeSet)) {
+		enabled = supported && forceCompleteModeSet != 0;
+		DBGLOG("weg", "force complete-modeset overriden by device property %u -> %d", forceCompleteModeSet, enabled);
+	} else if (info->firmwareVendor == DeviceInfo::FirmwareVendor::Apple) {
+		enabled = false; // may interfere with FV2
+		DBGLOG("weg", "force complete-modeset overriden by Apple firmware -> %d", enabled);
+	}
+	
+	if (enabled) {
+		uint64_t fbs;
+		if (PE_parse_boot_argn("igfxfcmsfbs", &fbs, sizeof(fbs)) ||
+			WIOKit::getOSDataValue(info->videoBuiltin, "complete-modeset-framebuffers", fbs)) {
+			for (size_t i = 0; i < arrsize(this->fbs); i++)
+				this->fbs[i] = (fbs >> (8 * i)) & 0xffU;
+			customised = true;
+		}
+	}
+}
+
+void IGFX::ForceCompleteModeset::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	KernelPatcher::RouteRequest request = {
+		legacy ?
+		"__ZN31AppleIntelFramebufferController16hwRegsNeedUpdateEP21AppleIntelFramebufferP21AppleIntelDisplayPathPNS_10CRTCParamsE" :
+		"__ZN31AppleIntelFramebufferController16hwRegsNeedUpdateEP21AppleIntelFramebufferP21AppleIntelDisplayPathPNS_10CRTCParamsEPK29IODetailedTimingInformationV2",
+		wrapHwRegsNeedUpdate,
+		orgHwRegsNeedUpdate
+	};
+	
+	if (!patcher.routeMultiple(index, &request, 1, address, size))
+		SYSLOG("igfx", "FCM: Failed to route the function hwRegsNeedUpdate.");
+}
+
+bool IGFX::ForceCompleteModeset::wrapHwRegsNeedUpdate(void *controller, IORegistryEntry *framebuffer, void *displayPath, void *crtParams, void *detailedInfo) {
+	// The framebuffer controller can perform panel fitter, partial, or a
+	// complete modeset (see AppleIntelFramebufferController::hwSetMode).
+	// In a dual-monitor CFL DVI+HDMI setup, only HDMI output was working after
+	// boot: it was observed that for HDMI framebuffer a complete modeset
+	// eventually occured, but for DVI it never did until after sleep and wake
+	// sequence.
+	//
+	// Function AppleIntelFramebufferController::hwRegsNeedUpdate checks
+	// whether a complete modeset needs to be issued. It does so by comparing
+	// sets of pipes and transcoder parameters. For some reason, the result was
+	// never true in the above scenario, so a complete modeset never occured.
+	// Consequently, AppleIntelFramebufferController::LightUpTMDS was never
+	// called for that framebuffer.
+	//
+	// Patching hwRegsNeedUpdate to always return true seems to be a rather
+	// safe solution to that. Note that the root cause of the problem is
+	// somewhere deeper.
+
+	// On older Skylake versions this function has no detailedInfo and does not use framebuffer argument.
+	// As a result the compiler does not pass framebuffer to the target function. Since the fix is disabled
+	// by default for Skylake, just force complete modeset on all framebuffers when actually requested.
+	if (callbackIGFX->modForceCompleteModeset.legacy)
+		return true;
+
+	// Either this framebuffer is in override list
+	if (callbackIGFX->modForceCompleteModeset.customised) {
+		return callbackIGFX->modForceCompleteModeset.inList(framebuffer) || callbackIGFX->modForceCompleteModeset.orgHwRegsNeedUpdate(controller, framebuffer, displayPath, crtParams, detailedInfo);
+	}
+
+	// Or it is not built-in, as indicated by AppleBacklightDisplay setting property "built-in" for
+	// this framebuffer.
+	// Note we need to check this at every invocation, as this property may reappear
+	return !framebuffer->getProperty("built-in") || callbackIGFX->modForceCompleteModeset.orgHwRegsNeedUpdate(controller, framebuffer, displayPath, crtParams, detailedInfo);
+}
+
+// MARK: - Force Online Display
+
+void IGFX::ForceOnlineDisplay::init() {
+	// We only need to patch the framebuffer driver
+	requiresPatchingFramebuffer = true;
+}
+
+void IGFX::ForceOnlineDisplay::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+	uint32_t forceOnline = 0;
+	if (PE_parse_boot_argn("igfxonln", &forceOnline, sizeof(forceOnline))) {
+		enabled = forceOnline != 0;
+		DBGLOG("weg", "force online overriden by boot-argument %u", forceOnline);
+	} else if (WIOKit::getOSDataValue(info->videoBuiltin, "force-online", forceOnline)) {
+		enabled = forceOnline != 0;
+		DBGLOG("weg", "force online overriden by device property %u", forceOnline);
+	}
+
+	if (enabled) {
+		uint64_t fbs;
+		if (PE_parse_boot_argn("igfxonlnfbs", &fbs, sizeof(fbs)) ||
+			WIOKit::getOSDataValue(info->videoBuiltin, "force-online-framebuffers", fbs)) {
+			for (size_t i = 0; i < arrsize(this->fbs); i++)
+				this->fbs[i] = (fbs >> (8 * i)) & 0xffU;
+			customised = true;
+		}
+	}
+}
+
+void IGFX::ForceOnlineDisplay::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	KernelPatcher::RouteRequest request = {
+		"__ZN21AppleIntelFramebuffer16getDisplayStatusEP21AppleIntelDisplayPath",
+		wrapGetDisplayStatus,
+		orgGetDisplayStatus
+	};
+	
+	if (!patcher.routeMultiple(index, &request, 1, address, size))
+		SYSLOG("igfx", "FOD: Failed to route the function getDisplayStatus.");
+}
+
+uint32_t IGFX::ForceOnlineDisplay::wrapGetDisplayStatus(IORegistryEntry *framebuffer, void *displayPath) {
+	// 0 - offline, 1 - online, 2 - empty dongle.
+	uint32_t ret = callbackIGFX->modForceOnlineDisplay.orgGetDisplayStatus(framebuffer, displayPath);
+	if (ret != 1) {
+		if (callbackIGFX->modForceOnlineDisplay.customised)
+			ret = callbackIGFX->modForceOnlineDisplay.inList(framebuffer) ? 1 : ret;
+		else
+			ret = 1;
+	}
+
+	DBGLOG("igfx", "getDisplayStatus forces %u", ret);
+	return ret;
+}
+
+// MARK: TODO
+
 IOReturn IGFX::wrapPavpSessionCallback(void *intelAccelerator, int32_t sessionCommand, uint32_t sessionAppId, uint32_t *a4, bool flag) {
 	//DBGLOG("igfx, "pavpCallback: cmd = %d, flag = %d, app = %u, a4 = %s", sessionCommand, flag, sessionAppId, a4 == nullptr ? "null" : "not null");
 
@@ -932,46 +1007,6 @@ bool IGFX::wrapAcceleratorStart(IOService *that, IOService *provider) {
 	return ret;
 }
 
-bool IGFX::wrapHwRegsNeedUpdate(void *controller, IOService *framebuffer, void *displayPath, void *crtParams, void *detailedInfo) {
-	// The framebuffer controller can perform panel fitter, partial, or a
-	// complete modeset (see AppleIntelFramebufferController::hwSetMode).
-	// In a dual-monitor CFL DVI+HDMI setup, only HDMI output was working after
-	// boot: it was observed that for HDMI framebuffer a complete modeset
-	// eventually occured, but for DVI it never did until after sleep and wake
-	// sequence.
-	//
-	// Function AppleIntelFramebufferController::hwRegsNeedUpdate checks
-	// whether a complete modeset needs to be issued. It does so by comparing
-	// sets of pipes and transcoder parameters. For some reason, the result was
-	// never true in the above scenario, so a complete modeset never occured.
-	// Consequently, AppleIntelFramebufferController::LightUpTMDS was never
-	// called for that framebuffer.
-	//
-	// Patching hwRegsNeedUpdate to always return true seems to be a rather
-	// safe solution to that. Note that the root cause of the problem is
-	// somewhere deeper.
-
-	// On older Skylake versions this function has no detailedInfo and does not use framebuffer argument.
-	// As a result the compiler does not pass framebuffer to the target function. Since the fix is disabled
-	// by default for Skylake, just force complete modeset on all framebuffers when actually requested.
-	if (callbackIGFX->forceCompleteModeset.legacy)
-		return true;
-
-	// Either this framebuffer is in override list
-	if (callbackIGFX->forceCompleteModeset.customised) {
-		return callbackIGFX->forceCompleteModeset.inList(framebuffer)
-		|| FunctionCast(callbackIGFX->wrapHwRegsNeedUpdate, callbackIGFX->orgHwRegsNeedUpdate)(
-			controller, framebuffer, displayPath, crtParams, detailedInfo);
-	}
-
-	// Or it is not built-in, as indicated by AppleBacklightDisplay setting property "built-in" for
-	// this framebuffer.
-	// Note we need to check this at every invocation, as this property may reappear
-	return !framebuffer->getProperty("built-in")
-			|| FunctionCast(callbackIGFX->wrapHwRegsNeedUpdate, callbackIGFX->orgHwRegsNeedUpdate)(
-			controller, framebuffer, displayPath, crtParams, detailedInfo);
-}
-
 IOReturn IGFX::wrapFBClientDoAttribute(void *fbclient, uint32_t attribute, unsigned long *unk1, unsigned long unk2, unsigned long *unk3, unsigned long *unk4, void *externalMethodArguments) {
 	if (attribute == kAGDCRegisterCallback) {
 		DBGLOG("igfx", "ignoring AGDC registration in FBClientControl::doAttribute");
@@ -990,20 +1025,6 @@ IOReturn IGFX::wrapFBClientDoAttribute(void *fbclient, uint32_t attribute, unsig
 uint64_t IGFX::wrapIsTypeCOnlySystem(void*) {
 	DBGLOG("igfx", "Forcing IsTypeCOnlySystem 0");
 	return 0;
-}
-
-uint32_t IGFX::wrapGetDisplayStatus(IOService *framebuffer, void *displayPath) {
-	// 0 - offline, 1 - online, 2 - empty dongle.
-	uint32_t ret = FunctionCast(wrapGetDisplayStatus, callbackIGFX->orgGetDisplayStatus)(framebuffer, displayPath);
-	if (ret != 1) {
-		if (callbackIGFX->forceOnlineDisplay.customised)
-			ret = callbackIGFX->forceOnlineDisplay.inList(framebuffer) ? 1 : ret;
-		else
-			ret = 1;
-	}
-
-	DBGLOG("igfx", "getDisplayStatus forces %u", ret);
-	return ret;
 }
 
 void IGFX::wrapCflWriteRegister32(void *that, uint32_t reg, uint32_t value) {

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -229,9 +229,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 		PE_parse_boot_argn("igfxmetal", &metal, sizeof(metal));
 		forceMetal = metal == 1;
 
-		// Starting from 10.14.4b1 Skylake+ graphics randomly kernel panics on GPU usage
-		readDescriptorPatch = cpuGeneration >= CPUInfo::CpuGeneration::Skylake && getKernelVersion() >= KernelVersion::Mojave;
-
 		// Automatically enable HDMI -> DP patches
 		bool nohdmi = info->videoBuiltin->getProperty("disable-hdmi-patches") != nullptr;
 		hdmiAutopatch = !applyFramebufferPatch && !connectorLessFrame && getKernelVersion() >= Yosemite &&
@@ -271,8 +268,6 @@ void IGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 				return true;
 			if (fwLoadMode != FW_APPLE)
 				return true;
-			if (readDescriptorPatch)
-				return true;
 			if (disableAccel)
 				return true;
 			return false;
@@ -311,11 +306,6 @@ bool IGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 
 			if (fwLoadMode == FW_GENERIC && getKernelVersion() <= KernelVersion::Mojave)
 				loadIGScheduler4Patches(patcher, index, address, size);
-		}
-
-		if (readDescriptorPatch) {
-			KernelPatcher::RouteRequest request("__ZNK25IGHardwareGlobalPageTable4readEyRyS0_", globalPageTableRead);
-			patcher.routeMultiple(index, &request, 1, address, size);
 		}
 		
 		// Iterate through each submodule and redirect the request if and only if the submodule is enabled
@@ -927,9 +917,29 @@ IOReturn IGFX::PAVPDisabler::wrapPavpSessionCallback(void *intelAccelerator, int
 	return callbackIGFX->modPAVPDisabler.orgPavpSessionCallback(intelAccelerator, sessionCommand, sessionAppId, a4, flag);
 }
 
-// MARK: - TODO
+// MARK: - Read Descriptors Patch
 
-bool IGFX::globalPageTableRead(void *hardwareGlobalPageTable, uint64_t address, uint64_t &physAddress, uint64_t &flags) {
+void IGFX::ReadDescriptorPatch::init() {
+	// We only need to patch the accelerator driver
+	requiresPatchingGraphics = true;
+}
+
+void IGFX::ReadDescriptorPatch::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+	// Starting from 10.14.4b1 Skylake+ graphics randomly kernel panics on GPU usage
+	enabled = BaseDeviceInfo::get().cpuGeneration >= CPUInfo::CpuGeneration::Skylake && getKernelVersion() >= KernelVersion::Mojave;
+}
+
+void IGFX::ReadDescriptorPatch::processGraphicsKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	KernelPatcher::RouteRequest request = {
+		"__ZNK25IGHardwareGlobalPageTable4readEyRyS0_",
+		globalPageTableRead
+	};
+	
+	if (!patcher.routeMultiple(index, &request, 1, address, size))
+		SYSLOG("igfx", "RDP: Failed to route the function IGHardwareGlobalPageTable::read.");
+}
+
+bool IGFX::ReadDescriptorPatch::globalPageTableRead(void *hardwareGlobalPageTable, uint64_t address, uint64_t &physAddress, uint64_t &flags) {
 	uint64_t pageNumber = address >> PAGE_SHIFT;
 	uint64_t pageEntry = getMember<uint64_t *>(hardwareGlobalPageTable, 0x28)[pageNumber];
 	// PTE: Page Table Entry for 4KB Page, page 82:
@@ -982,6 +992,8 @@ bool IGFX::globalPageTableRead(void *hardwareGlobalPageTable, uint64_t address, 
 	// over page table instead of obtaining valid mapped physical address.
 	return (flags & 3U) != 0;
 }
+
+// MARK: - TODO
 
 OSObject *IGFX::wrapCopyExistingServices(OSDictionary *matching, IOOptionBits inState, IOOptionBits options) {
 	if (matching && inState == kIOServiceMatchedState && options == 0) {

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -445,6 +445,50 @@ private:
 	} ForceWakeWorkaround;
 	
 	/**
+	 *  Describes how to inject code into a shared submodule
+	 *
+	 *  @tparam T Specify the type of the trigger
+	 *  @tparam I Specify the type of the function to inject code
+	 *  @tparam D Specify the concrete type of the descriptor
+	 *  @example The trigger type can be an integer type to inject code based on a register address.
+	 */
+	template <typename T, typename I, typename D>
+	struct InjectionDescriptor {
+		/**
+		 *  The trigger value to be monitored by the coordinator
+		 */
+		T trigger;
+
+		/**
+		 *  A function to invoke when the trigger value is observed
+		 *
+		 *  @example One may monitor a specific register address and modify its value in the injector function.
+		 */
+		I injector;
+
+		/**
+		 *  A pointer to the next descriptor in a linked list
+		 */
+		D *next;
+
+		/**
+		 *  Create an injection descriptor conveniently
+		 */
+		InjectionDescriptor(T t, I i) :
+			trigger(t), injector(i), next(nullptr) { }
+		
+		/**
+		 *  Member type `Trigger` is required by the coordinator
+		 */
+		using Trigger = T;
+		
+		/**
+		 *  Member type `Injector` is required by the coordinator
+		 */
+		using Injector = I;
+	};
+	
+	/**
 	 *  Interface of a submodule to fix Intel graphics drivers
 	 */
 	class PatchSubmodule {

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -455,19 +455,24 @@ private:
 		virtual ~PatchSubmodule() = default;
 		
 		/**
-		 *  True if this submodule should be enabled
+		 *  Set to `true` if this submodule should be enabled
 		 */
 		bool enabled {false};
 		
 		/**
-		 *  True if this submodule requires patching the framebuffer driver
+		 *  Set to `true` if this submodule requires patching the framebuffer driver
 		 */
 		bool requiresPatchingFramebuffer {false};
 		
 		/**
-		 *  True if this submodule requires patching the graphics acceleration driver
+		 *  Set to `true` if this submodule requires patching the graphics acceleration driver
 		 */
 		bool requiresPatchingGraphics {false};
+		
+		/**
+		 *  Set to `true` if this submodule requires accessing global framebuffer controllers
+		 */
+		bool requiresAccessingToGlobalFramebufferControllers {false};
 		
 		/**
 		 *  Initialize any data structure required by this submodule if necessary

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -228,11 +228,6 @@ private:
 	KernelPatcher::KextInfo *currentFramebufferOpt {nullptr};
 
 	/**
-	 *  Original PAVP session callback function used for PAVP command handling
-	 */
-	mach_vm_address_t orgPavpSessionCallback {};
-
-	/**
 	 *  Original IOService::copyExistingServices function from the kernel
 	 */
 	mach_vm_address_t orgCopyExistingServices {};
@@ -300,11 +295,6 @@ private:
 	 *  - laptop with CFL CPU and CFL IGPU drivers turns patch on
 	 */
 	CoffeeBacklightPatch cflBacklightPatch {CoffeeBacklightPatch::Off};
-
-	/**
-	 *  Set to true if PAVP code should be disabled
-	 */
-	bool pavpDisablePatch {false};
 
 	/**
 	 *  Set to true if read descriptor patch should be enabled
@@ -1333,6 +1323,27 @@ private:
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 	} modBlackScreenFix;
 	
+	/**
+	 *  A submodule to disable PAVP code and thus prevent freezes
+	 */
+	class PAVPDisabler: public PatchSubmodule {
+		/**
+		 *  Original PAVP session callback function used for PAVP command handling
+		 */
+		IOReturn (*orgPavpSessionCallback)(void *, int32_t, uint32_t, uint32_t *, bool) {nullptr};
+		
+		/**
+		 *  PAVP session callback wrapper used to prevent freezes on incompatible PAVP certificates
+		 */
+		static IOReturn wrapPavpSessionCallback(void *intelAccelerator, int32_t sessionCommand, uint32_t sessionAppId, uint32_t *a4, bool flag);
+		
+	public:
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
+		void processGraphicsKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modPAVPDisabler;
+	
 	//
 	// MARK: Shared Submodules
 	//
@@ -1610,11 +1621,6 @@ private:
 			return false;
 		}
 	};
-	
-	/**
-	 *  PAVP session callback wrapper used to prevent freezes on incompatible PAVP certificates
-	 */
-	static IOReturn wrapPavpSessionCallback(void *intelAccelerator, int32_t sessionCommand, uint32_t sessionAppId, uint32_t *a4, bool flag);
 
 	/**
 	 *  Global page table read wrapper for Kaby Lake.

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -562,6 +562,7 @@ private:
 		
 		// MARK: Patch Submodule IMP
 		void init() override;
+		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 		void disableDependentSubmodules() override;
 	} modFramebufferControllerAccessSupport;
@@ -1287,7 +1288,7 @@ private:
 	/**
 	 *  A submodule that applies patches based on the framebuffer index
 	 */
-	class FramebufferModiferV2: public PatchSubmodule {
+	class FramebufferModifer: public PatchSubmodule {
 	protected:
 		/**
 		 *  Indices of framebuffers to be patched
@@ -1326,7 +1327,7 @@ private:
 	/**
 	 *  A submodule to ensure that each modeset operation is a complete one
 	 */
-	class ForceCompleteModeset: public FramebufferModiferV2 {
+	class ForceCompleteModeset: public FramebufferModifer {
 		/**
 		 *  Original AppleIntelFramebufferController::hwRegsNeedUpdate function
 		 */
@@ -1347,7 +1348,7 @@ private:
 	/**
 	 *  A submodule to ensure that each display is online
 	 */
-	class ForceOnlineDisplay: public FramebufferModiferV2 {
+	class ForceOnlineDisplay: public FramebufferModifer {
 		/**
 		 *  Original AppleIntelFramebuffer::getDisplayStatus function
 		 */
@@ -1581,9 +1582,36 @@ private:
 	} modFramebufferDebugSupport;
 	
 	/**
+	 *  A collection of shared submodules
+	 */
+	PatchSubmodule *sharedSubmodules[3] = {
+		&modFramebufferControllerAccessSupport,
+		&modMMIORegistersReadSupport,
+		&modMMIORegistersWriteSupport
+	};
+	
+	/**
 	 *	A collection of submodules
 	 */
-	PatchSubmodule *submodules[6] = { &modDVMTCalcFix, &modDPCDMaxLinkRateFix, &modCoreDisplayClockFix, &modHDMIDividersCalcFix, &modLSPCONDriverSupport, &modAdvancedI2COverAUXSupport };
+	PatchSubmodule *submodules[17] = {
+		&modDVMTCalcFix,
+		&modDPCDMaxLinkRateFix,
+		&modCoreDisplayClockFix,
+		&modHDMIDividersCalcFix,
+		&modLSPCONDriverSupport,
+		&modAdvancedI2COverAUXSupport,
+		&modRPSControlPatch,
+		&modForceWakeWorkaround,
+		&modForceCompleteModeset,
+		&modForceOnlineDisplay,
+		&modAGDCDisabler,
+		&modTypeCCheckDisabler,
+		&modBlackScreenFix,
+		&modPAVPDisabler,
+		&modReadDescriptorPatch,
+		&modBacklightRegistersFix,
+		&modFramebufferDebugSupport
+	};
 	
 	/**
 	 * Prevent IntelAccelerator from starting.

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -1485,6 +1485,8 @@ private:
 	
 	/**
 	 *  A submodule to patch backlight register values and thus avoid 3-minute black screen on KBL+
+	 *
+	 *  @note Supported Platforms: KBL, CFL, ICL.
 	 */
 	class BacklightRegistersFix: public PatchSubmodule {
 		/**
@@ -1516,50 +1518,50 @@ private:
 		uint32_t driverBacklightFrequency {};
 		
 		/**
-		 *  [KBL] Wrapper to fix the value of BXT_BLC_PWM_FREQ1
+		 *  [KBL*] Wrapper to fix the value of BXT_BLC_PWM_FREQ1
 		 *
 		 *  @note When this function is called, `reg` is guaranteed to be `BXT_BLC_PWM_FREQ1`.
 		 */
 		static void wrapKBLWriteRegisterPWMFreq1(void *controller, uint32_t reg, uint32_t value);
 		
 		/**
-		 *  [KBL] Wrapper to fix the value of BXT_BLC_PWM_CTL1
+		 *  [KBL*] Wrapper to fix the value of BXT_BLC_PWM_CTL1
 		 *
 		 *  @note When this function is called, `reg` is guaranteed to be `BXT_BLC_PWM_CTL1`.
 		 */
 		static void wrapKBLWriteRegisterPWMCtrl1(void *controller, uint32_t reg, uint32_t value);
 		
 		/**
-		 *  [CFL, ICL] Wrapper to fix the value of BXT_BLC_PWM_FREQ1
+		 *  [CFL+] Wrapper to fix the value of BXT_BLC_PWM_FREQ1
 		 *
 		 *  @note When this function is called, `reg` is guaranteed to be `BXT_BLC_PWM_FREQ1`.
 		 */
 		static void wrapCFLWriteRegisterPWMFreq1(void *controller, uint32_t reg, uint32_t value);
 		
 		/**
-		 *  [CFL, ICL] Wrapper to fix the value of BXT_BLC_PWM_DUTY1
+		 *  [CFL+] Wrapper to fix the value of BXT_BLC_PWM_DUTY1
 		 *
 		 *  @note When this function is called, `reg` is guaranteed to be `BXT_BLC_PWM_DUTY1`.
 		 */
 		static void wrapCFLWriteRegisterPWMDuty1(void *controller, uint32_t reg, uint32_t value);
 		
 		/**
-		 *  [KBL] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_FREQ1
+		 *  [KBL*] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_FREQ1
 		 */
 		MMIOWriteInjectionDescriptor dKBLPWMFreq1 {BXT_BLC_PWM_FREQ1, wrapKBLWriteRegisterPWMFreq1};
 		
 		/**
-		 *  [KBL] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_CTL1
+		 *  [KBL*] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_CTL1
 		 */
 		MMIOWriteInjectionDescriptor dKBLPWMCtrl1 {BXT_BLC_PWM_CTL1 , wrapKBLWriteRegisterPWMCtrl1};
 		
 		/**
-		 *  [CFL, ICL] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_FREQ1
+		 *  [CFL+] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_FREQ1
 		 */
 		MMIOWriteInjectionDescriptor dCFLPWMFreq1 {BXT_BLC_PWM_FREQ1, wrapCFLWriteRegisterPWMFreq1};
 		
 		/**
-		 *  [CFL, ICL] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_DUTY1
+		 *  [CFL+] A replacer descriptor that injects code when the register of interest is BXT_BLC_PWM_DUTY1
 		 */
 		MMIOWriteInjectionDescriptor dCFLPWMDuty1 {BXT_BLC_PWM_DUTY1, wrapCFLWriteRegisterPWMDuty1};
 		

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -472,7 +472,17 @@ private:
 		/**
 		 *  Set to `true` if this submodule requires accessing global framebuffer controllers
 		 */
-		bool requiresAccessingToGlobalFramebufferControllers {false};
+		bool requiresGlobalFramebufferControllersAccess {false};
+		
+		/**
+		 *  Set to `true` if this submodules requires read access to MMIO registers
+		 */
+		bool requiresMMIORegistersReadAccess {false};
+		
+		/**
+		 *  Set to `true` if this submodules requires write access to MMIO registers
+		 */
+		bool requiresMMIORegistersWriteAccess {false};
 		
 		/**
 		 *  Initialize any data structure required by this submodule if necessary

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -489,6 +489,65 @@ private:
 	};
 	
 	/**
+	 *  Represents a list of injection descriptors
+	 *
+	 *  @tparam D Specify the concrete type of the descriptor
+	 */
+	template <typename D>
+	struct InjectionDescriptorList {
+	private:
+		/**
+		 *  Head of the list
+		 */
+		D *head {nullptr};
+		
+		/**
+		 *  Tail of the list
+		 */
+		D *tail {nullptr};
+		
+	public:
+		/**
+		 *  Get the injector function associated with the given trigger
+		 *
+		 *  @param trigger The trigger value
+		 *  @return The injector function on success, `nullptr` if the given trigger is not in the list.
+		 */
+		typename D::Injector getInjector(typename D::Trigger trigger) {
+			for (auto current = head; current != nullptr; current = current->next)
+				if (current->trigger == trigger)
+					return current->injector;
+			
+			return nullptr;
+		}
+		
+		/**
+		 *  Add an injection descriptor to the list
+		 *
+		 *  @param descriptor A non-null descriptor that specifies the trigger and the injector function
+		 *  @warning Patch developers must ensure that triggers are unique.
+		 *           The coordinator registers injections on a first come, first served basis.
+		 *           i.e. The latter descriptor will NOT overwrite the injection function of the existing one.
+		 *  @note This function assumes that the trigger value of the given descriptor has not been registered yet.
+		 */
+		void add(D *descriptor NONNULL) {
+			// Sanitize garbage value
+			descriptor->next = nullptr;
+			
+			// Append the new descriptor
+			if (head == nullptr)
+				// Empty list
+				head = descriptor;
+			else
+				// Non-empty list
+				tail->next = descriptor;
+			
+			// Update the tail
+			tail = descriptor;
+		}
+	};
+	
+	/**
 	 *  Interface of a submodule to fix Intel graphics drivers
 	 */
 	class PatchSubmodule {

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -1282,7 +1282,7 @@ private:
 	public:
 		// MARK: Patch Submodule IMP
 		void init() override;
-		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+		void processGraphicsKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 	} modForceWakeWorkaround;
 	
 	/**

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -422,16 +422,6 @@ private:
 	// and the framebuffer controller now maintains an array of `ports`.
 	class AppleIntelPort;
 	
-	struct ForceWakeWorkaround {
-		bool enabled {false};
-
-		void initGraphics(IGFX&,KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size);
-		
-		static bool pollRegister(uint32_t, uint32_t, uint32_t, uint32_t);
-		static bool forceWakeWaitAckFallback(uint32_t, uint32_t, uint32_t);
-		static void forceWake(void*, uint8_t set, uint32_t dom, uint32_t);
-	} ForceWakeWorkaround;
-	
 	/**
 	 *  Describes how to inject code into a shared submodule
 	 *
@@ -1230,6 +1220,20 @@ private:
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 		void processGraphicsKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 	} modRPSControlPatch;
+	
+	/**
+	 *  A submodule that fixes the kernel panic due to a rare force wake timeout on KBL and CFL platforms.
+	 */
+	class ForceWakeWorkaround: public PatchSubmodule {
+		static bool pollRegister(uint32_t, uint32_t, uint32_t, uint32_t);
+		static bool forceWakeWaitAckFallback(uint32_t, uint32_t, uint32_t);
+		static void forceWake(void *, uint8_t set, uint32_t dom, uint32_t);
+		
+	public:
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modForceWakeWorkaround;
 	
 	//
 	// MARK: Shared Submodules

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -414,6 +414,7 @@ private:
 	// Populated at AppleIntelFramebufferController::start
 	// Useful for getting access to Read/WriteRegister, rather than having
 	// to compute the offsets
+	// TODO: DEPRECATED
 	AppleIntelFramebufferController** gFramebufferController {};
 	
 	// Available on ICL+
@@ -1063,6 +1064,31 @@ private:
 	 *  The LSPCON driver requires access to I2C-over-AUX transaction APIs
 	 */
 	friend class LSPCON;
+	
+	/**
+	 *  A submodule to provide shared access to global framebuffer controllers
+	 */
+	class FramebufferControllerAccessSupport: public PatchSubmodule {
+		/**
+		 *  An array of framebuffer controllers populated by `AppleIntelFramebufferController::start()`
+		 */
+		AppleIntelFramebufferController **controllers {};
+		
+	public:
+		/**
+		 *  Get the framebuffer controller at the given index
+		 */
+		AppleIntelFramebufferController *getController(size_t index) { return controllers[index]; }
+		
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modFramebufferControllerAccessSupport;
+	
+	/**
+	 *  [Convenient] Get the default framebuffer controller
+	 */
+	AppleIntelFramebufferController *defaultController() { return modFramebufferControllerAccessSupport.getController(0); }
 	
 	/**
 	 *	A collection of submodules

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -278,11 +278,6 @@ private:
 	mach_vm_address_t orgIgBufferGetGpuVirtualAddress {};
 
 	/**
-	 *  Original IntelFBClientControl::doAttribute function
-	 */
-	mach_vm_address_t orgFBClientDoAttribute {};
-
-	/**
 	 *  Original AppleIntelFramebufferController::ReadRegister32 function
 	 */
 	uint32_t (*orgCflReadRegister32)(void *, uint32_t) {nullptr};
@@ -340,11 +335,6 @@ private:
 	 *  Set to true if Sandy Bridge Gen6Accelerator should be renamed
 	 */
 	bool moderniseAccelerator {false};
-
-	/**
-	 *  Disable AGDC configuration
-	 */
-	bool disableAGDC {false};
 
 	/**
 	 *  GuC firmware loading scheme
@@ -1271,7 +1261,28 @@ private:
 		void init() override;
 		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
-	} modForceOnlineDisplay;	
+	} modForceOnlineDisplay;
+	
+	/**
+	 *  A submodule that disables Apple's Graphics Device Control (AGDC)
+	 */
+	class AGDCDisabler: public PatchSubmodule {
+		/**
+		 *  Original IntelFBClientControl::doAttribute function
+		 */
+		IOReturn (*orgFBClientDoAttribute)(void *, uint32_t, unsigned long *, unsigned long, unsigned long *, unsigned long *, void *) {nullptr};
+		
+		/**
+		 *  A wrapper to ignore AGDC registration request
+		 */
+		static IOReturn wrapFBClientDoAttribute(void *fbclient, uint32_t attribute, unsigned long *unk1, unsigned long unk2, unsigned long *unk3, unsigned long *unk4, void *externalMethodArguments);
+		
+	public:
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
+		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modAGDCDisabler;
 	
 	//
 	// MARK: Shared Submodules

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -410,12 +410,8 @@ private:
 	uint32_t (*AppleIntelFramebufferController__ReadRegister32)(void*,uint32_t) {};
 	void (*AppleIntelFramebufferController__WriteRegister32)(void*,uint32_t,uint32_t) {};
 
+	// The opaque framebuffer controller type on BDW+
 	class AppleIntelFramebufferController;
-	// Populated at AppleIntelFramebufferController::start
-	// Useful for getting access to Read/WriteRegister, rather than having
-	// to compute the offsets
-	// TODO: DEPRECATED
-	AppleIntelFramebufferController** gFramebufferController {};
 	
 	// Available on ICL+
 	// Apple has refactored quite a large amount of code into a new class `AppleIntelPort` in the ICL graphics driver,

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -233,12 +233,6 @@ private:
 	mach_vm_address_t orgPavpSessionCallback {};
 
 	/**
-	 *  Original AppleIntelFramebufferController::ComputeLaneCount function used for DP lane count calculation
-	 */
-	// TODO: DEPRECATED
-	mach_vm_address_t orgComputeLaneCount {};
-
-	/**
 	 *  Original IOService::copyExistingServices function from the kernel
 	 */
 	mach_vm_address_t orgCopyExistingServices {};
@@ -289,12 +283,6 @@ private:
 	 */
 	void (*orgCflWriteRegister32)(void *, uint32_t, uint32_t) {nullptr};
 	void (*orgKblWriteRegister32)(void *, uint32_t, uint32_t) {nullptr};
-
-	/**
-	 *  Set to true if a black screen ComputeLaneCount patch is required
-	 */
-	// TODO: DEPRECATED
-	bool blackScreenPatch {false};
 
 	/**
 	 *  Coffee Lake backlight patch configuration options
@@ -1307,6 +1295,44 @@ private:
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 	} modTypeCCheckDisabler;
 	
+	/**
+	 *  A submodule to fix the black screen on external HDMI/DVI displays
+	 */
+	class BlackScreenFix: public PatchSubmodule {
+		/**
+		 *  [Legacy] Original AppleIntelFramebufferController::ComputeLaneCount function
+		 *
+		 *  @note This function is used for DP lane count calculation.
+		 */
+		bool (*orgComputeLaneCount)(void *, void *, uint32_t, int, int *) {nullptr};
+		
+		/**
+		 *  [Nouveau] Original AppleIntelFramebufferController::ComputeLaneCount function
+		 *
+		 *  @note This function is used for DP lane count calculation.
+		 *  @note Available on KBL+ and as of macOS 10.14.1.
+		 */
+		bool (*orgComputeLaneCountNouveau)(void *, void *, int, int *) {nullptr};
+		
+		/**
+		 *  [Legacy] A wrapper to report a working lane count for HDMI/DVI connections
+		 */
+		static bool wrapComputeLaneCount(void *controller, void *detailedTiming, uint32_t bpp, int availableLanes, int *laneCount);
+		
+		/**
+		 *  [Nouveau] A wrapper to report a working lane count for HDMI/DVI connections
+		 *
+		 *  @note Available on KBL+ and as of macOS 10.14.1.
+		 */
+		static bool wrapComputeLaneCountNouveau(void *controller, void *detailedTiming, int availableLanes, int *laneCount);
+		
+	public:
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
+		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modBlackScreenFix;
+	
 	//
 	// MARK: Shared Submodules
 	//
@@ -1594,16 +1620,6 @@ private:
 	 *  Global page table read wrapper for Kaby Lake.
 	 */
 	static bool globalPageTableRead(void *hardwareGlobalPageTable, uint64_t a1, uint64_t &a2, uint64_t &a3);
-
-	/**
-	 *  DP ComputeLaneCount wrapper to report success on non-DP screens to avoid black screen
-	 */
-	static bool wrapComputeLaneCount(void *that, void *timing, uint32_t bpp, int32_t availableLanes, int32_t *laneCount);
-
-	/**
-	 *  DP ComputeLaneCount wrapper to report success on non-DP screens to avoid black screen (10.14.1+ KBL/CFL version)
-	 */
-	static bool wrapComputeLaneCountNouveau(void *that, void *timing, int32_t availableLanes, int32_t *laneCount);
 
 	/**
 	 *  copyExistingServices wrapper used to rename Gen6Accelerator from userspace calls

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -300,11 +300,6 @@ private:
 	 */
 	bool dumpFramebufferToDisk {false};
 
-	/**
-	 *  Trace framebuffer logic
-	 */
-	bool debugFramebuffer {false};
-
 	// The opaque framebuffer controller type on BDW+
 	class AppleIntelFramebufferController;
 	
@@ -1573,6 +1568,17 @@ private:
 		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 	} modBacklightRegistersFix;
+	
+	/**
+	 *  A submodule to provide support for debugging the framebuffer driver
+	 */
+	class FramebufferDebugSupport: public PatchSubmodule {
+	public:
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
+		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modFramebufferDebugSupport;
 	
 	/**
 	 *	A collection of submodules

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -1593,7 +1593,7 @@ private:
 	};
 	
 	/**
-	 *	A collection of submodules
+	 *  A collection of submodules
 	 */
 	PatchSubmodule *submodules[17] = {
 		&modDVMTCalcFix,

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -839,15 +839,6 @@ private:
 	 */
 	class CoreDisplayClockFix: public PatchSubmodule {
 		/**
-		 *  [ICL+] Original AppleIntelFramebufferController::ReadRegister32 function
-		 *
-		 *  @param that The implicit hidden framebuffer controller instance
-		 *  @param address Address of the MMIO register
-		 *  @return The 32-bit integer read from the register.
-		 */
-		uint32_t (*orgIclReadRegister32)(AppleIntelFramebufferController *, uint32_t) {nullptr};
-		
-		/**
 		 *  [ICL+] Original AppleIntelFramebufferController::probeCDClockFrequency function
 		 *
 		 *  @seealso Refer to the document of `wrapProbeCDClockFrequency()` below.

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -235,6 +235,7 @@ private:
 	/**
 	 *  Original AppleIntelFramebufferController::ComputeLaneCount function used for DP lane count calculation
 	 */
+	// TODO: DEPRECATED
 	mach_vm_address_t orgComputeLaneCount {};
 
 	/**
@@ -292,6 +293,7 @@ private:
 	/**
 	 *  Set to true if a black screen ComputeLaneCount patch is required
 	 */
+	// TODO: DEPRECATED
 	bool blackScreenPatch {false};
 
 	/**
@@ -1284,6 +1286,27 @@ private:
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 	} modAGDCDisabler;
 	
+	/**
+	 *  A submodule that disables the check of Type-C platforms
+	 */
+	class TypeCCheckDisabler: public PatchSubmodule {
+		/**
+		 *  A wrapper to always report that this is not a Type-C platform
+		 *
+		 *  @note Apparently, platforms with (ig-platform-id & 0xf != 0) have only Type C connectivity.
+		 *        Framebuffer kext uses this fact to sanitise connector type, forcing it to DP.
+		 *        This breaks many systems, so we undo this check.
+		 *        Affected drivers: KBL and newer?
+		 */
+		static bool wrapIsTypeCOnlySystem(void *controller);
+		
+	public:
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
+		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modTypeCCheckDisabler;
+	
 	//
 	// MARK: Shared Submodules
 	//
@@ -1451,11 +1474,6 @@ private:
 	 * Prevent IntelAccelerator from starting.
 	 */
 	bool disableAccel {false};
-
-	/**
-	 * Disable Type C framebuffer check.
-	 */
-	bool disableTypeCCheck {false};
 	
 	/**
 	 *  Perform platform table dump to ioreg
@@ -1650,13 +1668,6 @@ private:
 	 *  IGMappedBuffer::getGPUVirtualAddress wrapper to trick GuC firmware virtual addresses
 	 */
 	static uint64_t wrapIgBufferGetGpuVirtualAddress(void *that);
-
-	/**
-	 *  IntelFBClientControl::doAttribute wrapper to filter attributes like AGDC.
-	 */
-	static IOReturn wrapFBClientDoAttribute(void *fbclient, uint32_t attribute, unsigned long *unk1, unsigned long unk2, unsigned long *unk3, unsigned long *unk4, void *externalMethodArguments);
-	
-	static uint64_t wrapIsTypeCOnlySystem(void*);
 
 	/**
 	 *  Load GuC-specific patches and hooks

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -368,10 +368,9 @@ private:
 	 *
 	 *  @tparam T Specify the type of the trigger
 	 *  @tparam I Specify the type of the function to inject code
-	 *  @tparam D Specify the concrete type of the descriptor
 	 *  @example The trigger type can be an integer type to inject code based on a register address.
 	 */
-	template <typename T, typename I, typename D>
+	template <typename T, typename I>
 	struct InjectionDescriptor {
 		/**
 		 *  The trigger value to be monitored by the coordinator
@@ -388,7 +387,7 @@ private:
 		/**
 		 *  A pointer to the next descriptor in a linked list
 		 */
-		D *next;
+		InjectionDescriptor *next;
 
 		/**
 		 *  Create an injection descriptor conveniently
@@ -618,12 +617,7 @@ private:
 	 *  @note The injector function takes the controller along with the register address and returns void.
 	 *  @note The injection is performed before the original function is invoked.
 	 */
-	struct MMIOReadPrologue: InjectionDescriptor<uint32_t, void (*)(void *, uint32_t), MMIOReadPrologue> {
-		/**
-		 *  Inherits the constructor from the super class
-		 */
-		using InjectionDescriptor::InjectionDescriptor;
-	};
+	using MMIOReadPrologue = InjectionDescriptor<uint32_t, void (*)(void *, uint32_t)>;
 	
 	/**
 	 *  Defines the replacer injection descriptor for `AppleIntelFramebufferController::ReadRegister32()`
@@ -632,12 +626,7 @@ private:
 	 *  @note The injector function takes the controller along with the register address and returns the register value.
 	 *  @note The injection replaced the original function call.
 	 */
-	struct MMIOReadReplacer: InjectionDescriptor<uint32_t, uint32_t (*)(void *, uint32_t), MMIOReadReplacer> {
-		/**
-		 *  Inherits the constructor from the super class
-		 */
-		using InjectionDescriptor::InjectionDescriptor;
-	};
+	using MMIOReadReplacer = InjectionDescriptor<uint32_t, uint32_t (*)(void *, uint32_t)>;
 	
 	/**
 	 *  Defines the epilogue injection descriptor for `AppleIntelFramebufferController::ReadRegister32()`
@@ -646,12 +635,7 @@ private:
 	 *  @note The injector function takes the controller along with the register address and its value, and returns the new value.
 	 *  @note The injection is performed after the original function is invoked.
 	 */
-	struct MMIOReadEpilogue: InjectionDescriptor<uint32_t, uint32_t (*)(void *, uint32_t, uint32_t), MMIOReadEpilogue> {
-		/**
-		 *  Inherits the constructor from the super class
-		 */
-		using InjectionDescriptor::InjectionDescriptor;
-	};
+	using MMIOReadEpilogue = InjectionDescriptor<uint32_t, uint32_t (*)(void *, uint32_t, uint32_t)>;
 	
 	/**
 	 *  A submodule that provides read access to MMIO registers and coordinates injections to the read function
@@ -694,12 +678,7 @@ private:
 	 *  @note The injector function takes the controller along with the register address and its new value, and returns void.
 	 *  @note This type is shared by all three kinds of injection descriptors.
 	 */
-	struct MMIOWriteInjectionDescriptor: InjectionDescriptor<uint32_t, void (*)(void *, uint32_t, uint32_t), MMIOWriteInjectionDescriptor> {
-		/**
-		 *  Inherits the constructor from the super class
-		 */
-		using InjectionDescriptor::InjectionDescriptor;
-	};
+	using MMIOWriteInjectionDescriptor = InjectionDescriptor<uint32_t, void (*)(void *, uint32_t, uint32_t)>;
 	
 	/**
 	 *  A submodule that provides write access to MMIO registers and coordinates injections to the write function

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -1221,6 +1221,10 @@ private:
 	 */
 	friend class LSPCON;
 	
+	//
+	// MARK: Shared Submodules
+	//
+	
 	/**
 	 *  A submodule to provide shared access to global framebuffer controllers
 	 */
@@ -1241,11 +1245,6 @@ private:
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 		void disableDependentSubmodules() override;
 	} modFramebufferControllerAccessSupport;
-	
-	/**
-	 *  [Convenient] Get the default framebuffer controller
-	 */
-	AppleIntelFramebufferController *defaultController() { return modFramebufferControllerAccessSupport.getController(0); }
 	
 	/**
 	 *  Defines the prologue injection descriptor for `AppleIntelFramebufferController::ReadRegister32()`
@@ -1350,6 +1349,33 @@ private:
 		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
 		void disableDependentSubmodules() override;
 	} modMMIORegistersWriteSupport;
+	
+	/**
+	 *  [Convenient] Get the default framebuffer controller
+	 */
+	AppleIntelFramebufferController *defaultController() { return modFramebufferControllerAccessSupport.getController(0); }
+	
+	/**
+	 *  [Convenient] Invoke the original AppleIntelFramebufferController::ReadRegister32 function
+	 *
+	 *  @param controller The framebuffer controller instance
+	 *  @param address The register address
+	 *  @return The register value.
+	 */
+	uint32_t readRegister32(void *controller, uint32_t address) {
+		return modMMIORegistersReadSupport.orgReadRegister32(controller, address);
+	}
+	
+	/**
+	 *  [Convenient] Invoke the original AppleIntelFramebufferController::WriteRegister32 function
+	 *
+	 *  @param controller The framebuffer controller instance
+	 *  @param address The register address
+	 *  @param value The new register value
+	 */
+	void writeRegister32(void *controller, uint32_t address, uint32_t value) {
+		modMMIORegistersWriteSupport.orgWriteRegister32(controller, address, value);
+	}
 	
 	/**
 	 *	A collection of submodules

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -359,6 +359,13 @@ private:
 	// and the framebuffer controller now maintains an array of `ports`.
 	class AppleIntelPort;
 	
+	/**
+	 *  Get the real framebuffer in use from the given bundle index
+	 */
+	KernelPatcher::KextInfo *getRealFramebuffer(size_t index) {
+		return (currentFramebuffer && currentFramebuffer->loadIndex == index) ? currentFramebuffer : currentFramebufferOpt;
+	}
+	
 	//
 	// MARK: - Patch Submodule & Injection Kits
 	//

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -548,6 +548,39 @@ private:
 	};
 	
 	/**
+	 *  An injection coordinator is capable of coordinating multiple requests of injection to a shared function
+	 *
+	 *  @tparam P Specify the type of the prologue injection descriptor that defines how the coordinator injects code before it calls the original function
+	 *  @tparam R Specify the type of the replacer injection descriptor that defines how the coordinator replaces the original function implementation
+	 *  @tparam E Specify the type of the epilogue injection descriptor that defines how the coordinator injects code after it calls the original function
+	 *  @note Patch submodules inherited from this class get coordination support automatically.
+	 *  @note Patch submodules invoke the `add()` method of a list to register injections.
+	 */
+	template <typename P, typename R, typename E>
+	class InjectionCoordinator {
+	public:
+		/**
+		 *  Virtual destructor
+		 */
+		virtual ~InjectionCoordinator() = default;
+		
+		/**
+		 *  A list of prologue injection descriptors
+		 */
+		InjectionDescriptorList<P> prologueList;
+		
+		/**
+		 *  A list of replacer injection descriptors
+		 */
+		InjectionDescriptorList<R> replacerList;
+		
+		/**
+		 *  A list of epilogue injection descriptors
+		 */
+		InjectionDescriptorList<E> epilogueList;
+	};
+	
+	/**
 	 *  Interface of a submodule to fix Intel graphics drivers
 	 */
 	class PatchSubmodule {

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -660,6 +660,11 @@ private:
 		 *  @note This function is called when the main IGFX module processes the kext.
 		 */
 		virtual void processGraphicsKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {}
+		
+		/**
+		 *  Disable submodules that depend on this submodules
+		 */
+		virtual void disableDependentSubmodules() {}
 	};
 	
 	/**

--- a/WhateverGreen/kern_igfx_clock.cpp
+++ b/WhateverGreen/kern_igfx_clock.cpp
@@ -98,7 +98,7 @@ void IGFX::DPCDMaxLinkRateFix::init() {
 	// We only need to patch the framebuffer driver
 	requiresPatchingGraphics = false;
 	requiresPatchingFramebuffer = true;
-	requiresAccessingToGlobalFramebufferControllers = true;
+	requiresGlobalFramebufferControllersAccess = true;
 }
 
 void IGFX::DPCDMaxLinkRateFix::processKernel(KernelPatcher &patcher, DeviceInfo *info) {

--- a/WhateverGreen/kern_igfx_clock.cpp
+++ b/WhateverGreen/kern_igfx_clock.cpp
@@ -474,6 +474,9 @@ void IGFX::CoreDisplayClockFix::init() {
 	// We only need to patch the framebuffer driver
 	requiresPatchingGraphics = false;
 	requiresPatchingFramebuffer = true;
+	
+	// Requires read access to MMIO registers
+	requiresMMIORegistersReadAccess = true;
 }
 
 void IGFX::CoreDisplayClockFix::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
@@ -496,11 +499,8 @@ void IGFX::CoreDisplayClockFix::processFramebufferKext(KernelPatcher &patcher, s
 		{"__ZN31AppleIntelFramebufferController19setCDClockFrequencyEy", orgSetCDClockFrequency}
 	};
 	
-	orgIclReadRegister32 = reinterpret_cast<decltype(orgIclReadRegister32)>(callbackIGFX->AppleIntelFramebufferController__ReadRegister32);
-	
 	if (patcher.routeMultiple(index, &routeRequest, 1, address, size) &&
-		patcher.solveMultiple(index, solveRequests, address, size) &&
-		orgIclReadRegister32)
+		patcher.solveMultiple(index, solveRequests, address, size))
 		DBGLOG("igfx", "CDC: Functions have been routed successfully.");
 	else
 		SYSLOG("igfx", "CDC: Failed to route functions.");
@@ -509,7 +509,7 @@ void IGFX::CoreDisplayClockFix::processFramebufferKext(KernelPatcher &patcher, s
 void IGFX::CoreDisplayClockFix::sanitizeCDClockFrequency(AppleIntelFramebufferController *that) {
 	// Read the hardware reference frequency from the DSSM register
 	// Bits 29-31 store the reference frequency value
-	auto referenceFrequency = callbackIGFX->modCoreDisplayClockFix.orgIclReadRegister32(that, ICL_REG_DSSM) >> 29;
+	auto referenceFrequency = callbackIGFX->readRegister32(that, ICL_REG_DSSM) >> 29;
 	
 	// Frequency of Core Display Clock PLL is determined by the reference frequency
 	uint32_t newCdclkFrequency = 0;
@@ -552,7 +552,7 @@ void IGFX::CoreDisplayClockFix::sanitizeCDClockFrequency(AppleIntelFramebufferCo
 	DBGLOG("igfx", "CDC: sanitizeCDClockFrequency() DInfo: Core Display Clock has been reprogrammed and PLL has been re-enabled.");
 	
 	// "Verify" that the new frequency is effective
-	auto cdclk = callbackIGFX->modCoreDisplayClockFix.orgIclReadRegister32(that, ICL_REG_CDCLK_CTL) & 0x7FF;
+	auto cdclk = callbackIGFX->readRegister32(that, ICL_REG_CDCLK_CTL) & 0x7FF;
 	SYSLOG("igfx", "CDC: sanitizeCDClockFrequency() DInfo: Core Display Clock frequency is %s MHz now.",
 		   coreDisplayClockDecimalFrequency2String(cdclk));
 }
@@ -586,7 +586,7 @@ uint32_t IGFX::CoreDisplayClockFix::wrapProbeCDClockFrequency(AppleIntelFramebuf
 	
 	// Read the Core Display Clock frequency from the CDCLK_CTL register
 	// Bit 0 - 11 stores the decimal frequency
-	auto cdclk = callbackIGFX->modCoreDisplayClockFix.orgIclReadRegister32(that, ICL_REG_CDCLK_CTL) & 0x7FF;
+	auto cdclk = callbackIGFX->readRegister32(that, ICL_REG_CDCLK_CTL) & 0x7FF;
 	SYSLOG("igfx", "CDC: ProbeCDClockFrequency() DInfo: The current core display clock frequency is %s MHz.",
 		   coreDisplayClockDecimalFrequency2String(cdclk));
 	

--- a/WhateverGreen/kern_igfx_clock.cpp
+++ b/WhateverGreen/kern_igfx_clock.cpp
@@ -98,6 +98,7 @@ void IGFX::DPCDMaxLinkRateFix::init() {
 	// We only need to patch the framebuffer driver
 	requiresPatchingGraphics = false;
 	requiresPatchingFramebuffer = true;
+	requiresAccessingToGlobalFramebufferControllers = true;
 }
 
 void IGFX::DPCDMaxLinkRateFix::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
@@ -268,7 +269,7 @@ IOReturn IGFX::DPCDMaxLinkRateFix::orgReadAUX(uint32_t address, void *buffer, ui
 }
 
 bool IGFX::DPCDMaxLinkRateFix::getFramebufferIndex(uint32_t &index) {
-	auto fb = port != nullptr ? orgICLGetFBFromPort(*callbackIGFX->gFramebufferController, port) : this->framebuffer;
+	auto fb = port != nullptr ? orgICLGetFBFromPort(callbackIGFX->defaultController(), port) : this->framebuffer;
 	DBGLOG("igfx", "MLR: [COMM] GetFBIndex() Port at 0x%llx; Framebuffer at 0x%llx.", port, fb);
 	return AppleIntelFramebufferExplorer::getIndex(fb, index);
 }

--- a/WhateverGreen/kern_igfx_debug.cpp
+++ b/WhateverGreen/kern_igfx_debug.cpp
@@ -330,7 +330,7 @@ static IOReturn fbdebugWrapFBClientDoAttribute(void *fbclient, uint32_t attribut
 void IGFX::loadFramebufferDebug(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 	SYSLOG("igfx", "using framebuffer debug r15");
 
-	if (disableAGDC)
+	if (modAGDCDisabler.enabled)
 		PANIC("igfx", "igfxagdc=0 is not compatible with framebuffer debugging");
 
 	KernelPatcher::RouteRequest requests[] = {

--- a/WhateverGreen/kern_igfx_debug.cpp
+++ b/WhateverGreen/kern_igfx_debug.cpp
@@ -326,18 +326,6 @@ static IOReturn fbdebugWrapFBClientDoAttribute(void *fbclient, uint32_t attribut
 
 	return ret;
 }
-#endif
-
-void IGFX::FramebufferDebugSupport::init() {
-	// We only need to patch the framebuffer driver
-	requiresPatchingFramebuffer = true;
-}
-
-void IGFX::FramebufferDebugSupport::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
-#ifdef DEBUG
-	enabled = checkKernelArgument("-igfxfbdbg");
-#endif
-}
 
 void IGFX::FramebufferDebugSupport::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 	SYSLOG("igfx", "using framebuffer debug r15");
@@ -365,4 +353,21 @@ void IGFX::FramebufferDebugSupport::processFramebufferKext(KernelPatcher &patche
 
 	if (!patcher.routeMultiple(index, requests, address, size, true, true))
 		SYSLOG("igfx", "DBG: Failed to route igfx tracing.");
+}
+
+#else
+void IGFX::FramebufferDebugSupport::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	PANIC("igfx", "DBG: Framebuffer debug support is only available in debug build.");
+}
+#endif
+
+void IGFX::FramebufferDebugSupport::init() {
+	// We only need to patch the framebuffer driver
+	requiresPatchingFramebuffer = true;
+}
+
+void IGFX::FramebufferDebugSupport::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+#ifdef DEBUG
+	enabled = checkKernelArgument("-igfxfbdbg");
+#endif
 }

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -306,8 +306,8 @@ void IGFX::ForceWakeWorkaround::forceWake(void*, uint8_t set, uint32_t dom, uint
 }
 
 void IGFX::ForceWakeWorkaround::init() {
-	// We only need to patch the framebuffer driver
-	requiresPatchingFramebuffer = true;
+	// We only need to patch the acceleration driver
+	requiresPatchingGraphics = true;
 	
 	// Requires access to global framebuffer controllers
 	requiresGlobalFramebufferControllersAccess = true;
@@ -317,7 +317,7 @@ void IGFX::ForceWakeWorkaround::init() {
 	requiresMMIORegistersWriteAccess = true;
 }
 
-void IGFX::ForceWakeWorkaround::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+void IGFX::ForceWakeWorkaround::processGraphicsKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
 	KernelPatcher::RouteRequest request = {
 		"__ZN16IntelAccelerator26SafeForceWakeMultithreadedEbjj",
 		forceWake

--- a/WhateverGreen/kern_igfx_pm.cpp
+++ b/WhateverGreen/kern_igfx_pm.cpp
@@ -52,52 +52,6 @@ struct [[gnu::packed]] IGHwCsDesc {
   char unk1[12];
 };
 
-static bool patchRCSCheck(mach_vm_address_t& start) {
-	constexpr unsigned ninsts_max {256};
-	
-	hde64s dis;
-	
-	bool found_cmp = false;
-	bool found_jmp = false;
-
-	for (size_t i = 0; i < ninsts_max; i++) {
-		auto sz = Disassembler::hdeDisasm(start, &dis);
-
-		if (dis.flags & F_ERROR) {
-			SYSLOG(log, "Error disassembling submitExecList");
-			break;
-		}
-
-		/* cmp byte ptr [rcx], 0 */
-		if (!found_cmp && dis.opcode == 0x80 && dis.modrm_reg == 7 && dis.modrm_rm == 1)
-			found_cmp = true;
-		/* jnz rel32 */
-		if (found_cmp && dis.opcode == 0x0f && dis.opcode2 == 0x85) {
-			found_jmp = true;
-			break;
-		}
-
-		start += sz;
-	}
-	
-	if (found_jmp) {
-		auto status = MachInfo::setKernelWriting(true, KernelPatcher::kernelWriteLock);
-		if (status == KERN_SUCCESS) {
-			constexpr uint8_t nop6[] {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
-			lilu_os_memcpy(reinterpret_cast<void*>(start), nop6, arrsize(nop6));
-			MachInfo::setKernelWriting(false, KernelPatcher::kernelWriteLock);
-			DBGLOG(log, "Patched submitExecList");
-			return true;
-		} else {
-			DBGLOG(log, "Failed to set kernel writing");
-			return false;
-		}
-	} else {
-		SYSLOG(log, "jnz in submitExecList not found");
-		return false;
-	}
-}
-
 constexpr uint32_t MCHBAR_MIRROR_BASE_SNB = 0x140000;
 constexpr uint32_t GEN6_RP_STATE_CAP = MCHBAR_MIRROR_BASE_SNB + 0x5998;
 
@@ -169,58 +123,122 @@ constexpr uint32_t fw_clear(uint32_t v) {
 }
 }
 
-void IGFX::RPSControl::initGraphics(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
-	mach_vm_address_t orgIGHardwareCommandStreamer2__submitExecList {};
-	const char* sym = getKernelVersion() >= KernelVersion::Catalina ?
-	"__ZN26IGHardwareCommandStreamer514submitExecListEj" : "__ZN26IGHardwareCommandStreamer214submitExecListEj";
-	orgIGHardwareCommandStreamer2__submitExecList = patcher.solveSymbol(index, sym, address, size);
+// MARK: - RPS Control Patch
 
-	/**
-	 * IGHardwareCommandStreamer2::submitExecList only controls RPS for RCS type streamers.
-	 * Patch it to enable control for any kind of streamer.
-	 */
-	if (orgIGHardwareCommandStreamer2__submitExecList) {
-		mach_vm_address_t start = orgIGHardwareCommandStreamer2__submitExecList;
-		patchRCSCheck(start);
-		// The second patch is to get to patchFrequencyRequest (unused for now)
-//		patchRCSCheck(start);
-	} else {
-		SYSLOG(log, "Failed to solve submitExecList (%d)", patcher.getError());
-		patcher.clearError();
+void IGFX::RPSControlPatch::init() {
+	// We need to patch both drivers
+	requiresPatchingGraphics = true;
+	requiresPatchingFramebuffer = true;
+	
+	// Requires access to global framebuffer controllers
+	requiresGlobalFramebufferControllersAccess = true;
+	
+	// Requires read access to MMIO registers
+	requiresMMIORegistersReadAccess = true;
+}
+
+void IGFX::RPSControlPatch::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
+	uint32_t rpsc = 0;
+	if (PE_parse_boot_argn("igfxrpsc", &rpsc, sizeof(rpsc)) ||
+		WIOKit::getOSDataValue(info->videoBuiltin, "rps-control", rpsc)) {
+		enabled = rpsc > 0 && available;
+		DBGLOG("weg", "RPS control patch overriden (%u) availabile %d", rpsc, available);
 	}
 }
 
-/**
- * Request maximum RPS at exec list submission.
- * While this sounds dangerous, we are still getting proper power management due to
- * force wake clears.
- */
-int IGFX::RPSControl::pmNotifyWrapper(unsigned int a0,unsigned int a1,unsigned long long * a2,unsigned int * freq) {
-	uint32_t cfreq = 0;
-
-	FunctionCast(IGFX::RPSControl::pmNotifyWrapper, callbackIGFX->RPSControl.orgPmNotifyWrapper)(a0, a1, a2, &cfreq);
+void IGFX::RPSControlPatch::processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	KernelPatcher::RouteRequest routeRequest = {
+		"__ZL15pmNotifyWrapperjjPyPj",
+		wrapPmNotifyWrapper,
+		orgPmNotifyWrapper
+	};
 	
-	if (!callbackIGFX->RPSControl.freq_max) {
-		callbackIGFX->RPSControl.freq_max = callbackIGFX->AppleIntelFramebufferController__ReadRegister32(*callbackIGFX->gFramebufferController, GEN6_RP_STATE_CAP) & 0xff;
-		DBGLOG(log, "Read RP0 %d", callbackIGFX->RPSControl.freq_max);
+	if (!patcher.routeMultiple(index, &routeRequest, 1, address, size))
+		SYSLOG(log, "Failed to route pmNotifyWrapper.");
+}
+
+void IGFX::RPSControlPatch::processGraphicsKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
+	// Address of `IGHardwareCommandStreamer2::submitExecList`
+	mach_vm_address_t orgSubmitExecList;
+	
+	KernelPatcher::SolveRequest request = {
+		getKernelVersion() >= KernelVersion::Catalina ? "__ZN26IGHardwareCommandStreamer514submitExecListEj" : "__ZN26IGHardwareCommandStreamer214submitExecListEj",
+		orgSubmitExecList
+	};
+	
+	if (!patcher.solveMultiple(index, &request, 1, address, size)) {
+		SYSLOG(log, "Failed to solve the symbol for submitExecList.");
+		return;
 	}
 	
-//	DBGLOG(log, "pmNotifyWrapper sets freq 0x%x", cfreq);
-	*freq = (GEN9_FREQ_SCALER << GEN9_FREQUENCY_SHIFT) * callbackIGFX->RPSControl.freq_max;
+	// `submitExecList()` only controls RPS for RCS type streamers
+	// Patch it to enable control for any kind of streamer
+	if (!patchRCSCheck(orgSubmitExecList))
+		SYSLOG(log, "Failed to patch RCS check.");
+}
 
+int IGFX::RPSControlPatch::wrapPmNotifyWrapper(unsigned int a0, unsigned int a1, unsigned long long *a2, unsigned int *freq) {
+	// Request the maximum RPS at exec list submission
+	// While this sounds dangerous, we are still getting proper power management due to force wake clears.
+	uint32_t cfreq = 0;
+	callbackIGFX->modRPSControlPatch.orgPmNotifyWrapper(a0, a1, a2, &cfreq);
+	
+	if (!callbackIGFX->modRPSControlPatch.freq_max) {
+		callbackIGFX->modRPSControlPatch.freq_max = callbackIGFX->readRegister32(callbackIGFX->defaultController(), GEN6_RP_STATE_CAP) & 0xFF;
+		DBGLOG("log", "Read RP0 %d", callbackIGFX->modRPSControlPatch.freq_max);
+	}
+	
+	*freq = (GEN9_FREQ_SCALER << GEN9_FREQUENCY_SHIFT) * callbackIGFX->modRPSControlPatch.freq_max;
 	return 0;
 }
 
-void IGFX::RPSControl::initFB(IGFX& ig,KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) {
-	KernelPatcher::RouteRequest req {
-			"__ZL15pmNotifyWrapperjjPyPj",
-			&IGFX::RPSControl::pmNotifyWrapper,
-			orgPmNotifyWrapper
-	};
+bool IGFX::RPSControlPatch::patchRCSCheck(mach_vm_address_t& start) {
+	constexpr unsigned ninsts_max {256};
+	
+	hde64s dis;
+	
+	bool found_cmp = false;
+	bool found_jmp = false;
 
-	if (!(ig.AppleIntelFramebufferController__ReadRegister32 && ig.gFramebufferController && patcher.routeMultiple(index, &req, 1, address, size, true, true)))
-		SYSLOG(log, "failed to route igfx FB PM functions");
+	for (size_t i = 0; i < ninsts_max; i++) {
+		auto sz = Disassembler::hdeDisasm(start, &dis);
+
+		if (dis.flags & F_ERROR) {
+			SYSLOG(log, "Error disassembling submitExecList");
+			break;
+		}
+
+		/* cmp byte ptr [rcx], 0 */
+		if (!found_cmp && dis.opcode == 0x80 && dis.modrm_reg == 7 && dis.modrm_rm == 1)
+			found_cmp = true;
+		/* jnz rel32 */
+		if (found_cmp && dis.opcode == 0x0f && dis.opcode2 == 0x85) {
+			found_jmp = true;
+			break;
+		}
+
+		start += sz;
+	}
+	
+	if (found_jmp) {
+		auto status = MachInfo::setKernelWriting(true, KernelPatcher::kernelWriteLock);
+		if (status == KERN_SUCCESS) {
+			constexpr uint8_t nop6[] {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+			lilu_os_memcpy(reinterpret_cast<void*>(start), nop6, arrsize(nop6));
+			MachInfo::setKernelWriting(false, KernelPatcher::kernelWriteLock);
+			DBGLOG(log, "Patched submitExecList");
+			return true;
+		} else {
+			DBGLOG(log, "Failed to set kernel writing");
+			return false;
+		}
+	} else {
+		SYSLOG(log, "jnz in submitExecList not found");
+		return false;
+	}
 }
+
+// MARK: - Force Wake Workaround
 
 bool IGFX::ForceWakeWorkaround::pollRegister(uint32_t reg, uint32_t val, uint32_t mask, uint32_t timeout) {
 	AbsoluteTime now, deadline;


### PR DESCRIPTION
#### Abstract:

This PR converts more existing IGFX patches to submodules, revises the backlight fix to support ICL platforms, and introduces the concept of coordinated injections.  

#### Coordinated Injections

**Introduction:**
The *Coordinated Injections* module allows multiple submodules to inject code into a shared function. We classify common patterns of code injection as three categories, *prologue injection*, *replacer injection* and *epilogue injection*. The prologue injector injects code before calling the original function, while the epilogue one injects code after calling the original function. The replacer injector overwrites the original implementation and thus does not call the original function. As such, the coordinator maintains three lists of injection descriptors. 

An injection descriptor describes how to inject the code. It defines a trigger value that will be monitored by the coordinator, an injector function that will be called by the coordinator when the trigger value is observed, and a pointer to the next element in the linked list. Both trigger and injector function type are defined by a concrete submodule. Take the shared `ReadRegister32()` submodule as an example, we define the trigger as the register address, so if the graphics driver tries to read a value from that register, the coordinator would invoke the injector function. As a result, we can separate a giant wrapper function into multiple tiny ones where each of them deals with a specific register.

**Implementation:**
Submodules inherited from the `InjectionCoordinator` class get support of coordinated injections automatically, and patch developers do not need write any additional code. Currently, both `ReadRegister32()` and `WriteRegister32()` implement this feature and expose convenient helper functions to access the original implementation. Submodules that require access to these two functions must set their `requiresMMIORegistersReadAccess` and `requiresMMIORegistersWriteAccess` properties to `true` respectively. 

**Related Changes:**
- The backlight registers fix has been revised to use shared MMIO registers-related functions elegantly. It replaces the previous Coffee Lake backlight patch and now supports Intel Ice Lake platforms. As a result, the pull request https://github.com/acidanthera/WhateverGreen/pull/76 is no longer needed.
- A new shared submodule is added to allow other ones to access the global framebuffer controller instance. Similarly, submodules that require access to the global controller must set `requiresGlobalFramebufferControllersAccess` to `true`. As a result, all TODO items proposed in the pull request https://github.com/acidanthera/WhateverGreen/pull/72#discussion_r506913581 are now completed. 

**Future Changes:**
We will probably need to separate AUX registers-related functions into separate shared submodules as well. The maximum link rate fix is the only one that injects code to the `ReadAUX()` function. If separations are necessary, I will probably submit another PR along with a new fix that relies on it.

Thanks for your time,
FireWolf