### PR TITLE
IGFX: Add max pixel clock override submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ indices of connectors for which online status is enforced. Format is similar to 
 - `-igfxcdc` boot argument (`enable-cdclk-frequency-fix` property) to support all valid Core Display Clock (CDCLK) frequencies on ICL platforms. [Read the manual](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/FAQ.IntelHD.en.md)
 - `-igfxdvmt` boot argument (`enable-dvmt-calc-fix` property) to fix the kernel panic caused by an incorrectly calculated amount of DVMT pre-allocated memory on Intel ICL platforms.
 - `-igfxblr` boot argument (and `enable-backlight-registers-fix` property) to fix backlight registers on KBL, CFL and ICL platforms.
+- `-igfxmpc` boot argument (`enable-max-pixel-clock-override` and `max-pixel-clock-frequency` properties) to increase max pixel clock (as an alternative to patching CoreDisplay.framework).
 
 #### Credits
 

--- a/WhateverGreen/kern_igfx.cpp
+++ b/WhateverGreen/kern_igfx.cpp
@@ -1467,7 +1467,7 @@ void IGFX::loadIGScheduler4Patches(KernelPatcher &patcher, size_t index, mach_vm
 			patcher.clearError();
 		}
 	} else {
-		SYSLOG("igfx", "failed to resoolve __KmGen9GuCBinary %d", patcher.getError());
+		SYSLOG("igfx", "failed to resolve __KmGen9GuCBinary %d", patcher.getError());
 		patcher.clearError();
 	}
 }

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -1584,6 +1584,32 @@ private:
 	} modFramebufferDebugSupport;
 	
 	/**
+	 *  A submodule to override the max pixel clock limit in the framebuffer driver.
+	 */
+	class MaxPixelClockOverride: public PatchSubmodule {
+		/**
+		 * Override for max pixel clock frequency (Hz).
+		 */
+		uint64_t maxPixelClockFrequency = 675000000;
+
+		/**
+		 *  Original AppleIntelFramebuffer::connectionProbe function
+		 */
+		IOReturn (*orgConnectionProbe)(IOService *, unsigned int, unsigned int) {nullptr};
+
+		/**
+		 *  AppleIntelFramebuffer::connectionProbe wrapper to override max pixel clock
+		 */
+		static IOReturn wrapConnectionProbe(IOService *that, unsigned int unk1, unsigned int unk2);
+
+	public:
+		// MARK: Patch Submodule IMP
+		void init() override;
+		void processKernel(KernelPatcher &patcher, DeviceInfo *info) override;
+		void processFramebufferKext(KernelPatcher &patcher, size_t index, mach_vm_address_t address, size_t size) override;
+	} modMaxPixelClockOverride;
+
+	/**
 	 *  A collection of shared submodules
 	 */
 	PatchSubmodule *sharedSubmodules[3] = {
@@ -1595,7 +1621,7 @@ private:
 	/**
 	 *  A collection of submodules
 	 */
-	PatchSubmodule *submodules[17] = {
+	PatchSubmodule *submodules[18] = {
 		&modDVMTCalcFix,
 		&modDPCDMaxLinkRateFix,
 		&modCoreDisplayClockFix,
@@ -1612,7 +1638,8 @@ private:
 		&modPAVPDisabler,
 		&modReadDescriptorPatch,
 		&modBacklightRegistersFix,
-		&modFramebufferDebugSupport
+		&modFramebufferDebugSupport,
+		&modMaxPixelClockOverride
 	};
 	
 	/**


### PR DESCRIPTION
This can be used as an alternative to patching CoreDisplay.framework. Tested on KBL, but should work on other platforms.