### PR TITLE
IONDRVFramebuffer::_doControl denoiser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 WhateverGreen Changelog
 =======================
+#### v1.4.8
+- Fixed debug messages from cursor manipulation with NVIDIA GPUs on macOS 11
+
 #### v1.4.7
 - Implemented `unfairgva` device property (use `<01 00 00 00>` value for MP5,1 to enable streaming DRM)
 

--- a/WhateverGreen/kern_ngfx.cpp
+++ b/WhateverGreen/kern_ngfx.cpp
@@ -143,13 +143,16 @@ bool NGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 	if (kextList[IndexIONDRVSupport].loadIndex == index) {
 		if (getKernelVersion() > KernelVersion::Catalina) {
 			KernelPatcher::LookupPatch patch {&kextList[IndexIONDRVSupport], doControlFind, doControlRepl, sizeof(doControlFind), 1};
+
 			patcher.applyLookupPatch(&patch);
-			if (patcher.getError() != KernelPatcher::Error::NoError) {
-				SYSLOG("ngfx", "failed to apply _doControl patch (err code %d)", patcher.getError());
-				patcher.clearError();
-			}
+
+			KernelPatcher::Error rc = patcher.getError();
+
+			if (rc == KernelPatcher::Error::NoError) { return true; }
+
+			SYSLOG("ngfx", "failed to apply IONDRVFramebuffer::_doControl() patch [err code %d]", rc);
+			patcher.clearError();
 		}
-		return true;
 	}
 
 	return false;

--- a/WhateverGreen/kern_ngfx.cpp
+++ b/WhateverGreen/kern_ngfx.cpp
@@ -62,18 +62,6 @@ static const uint8_t doControlRepl[] = {
 	0x83, 0xBB, 0x18, 0x02, 0x00, 0x00, 0x00	// cmp dword [rbx] + 0x218], 0
 };
 
-static UserPatcher::BinaryModPatch doControlPatch {
-	CPU_TYPE_X86_64,
-	0,
-	doControlFind,
-	doControlRepl,
-	arrsize(doControlFind),
-	0,            // skip  = 0 -> replace all occurrences
-	1,            // count = 1 -> 1 set of hex inside the target binaries
-	UserPatcher::FileSegment::SegmentTextText,
-	0
-};
-
 NGFX *NGFX::callbackNGFX;
 
 void NGFX::init() {

--- a/WhateverGreen/kern_ngfx.cpp
+++ b/WhateverGreen/kern_ngfx.cpp
@@ -45,23 +45,6 @@ enum KextIndex {
 	IndexIONDRVSupport
 };
 
-// Patches
-
-// Suppress debug(?) noise from IONDRVFramebuffer::_doControl( IONDRVFramebuffer * fb, UInt32 code, void * params )
-// when function was compiled with #define IONDRVCHECK 1.
-// Ref: https://opensource.apple.com/source/IOGraphics/IOGraphics-585/IONDRVSupport/IONDRVFramebuffer.cpp.auto.html
-
-static const uint8_t doControlFind[] = {
-	0x85, 0xC0,							// test eax, eax
-	0x74, 0x34,							// je 0x25d1
-	0x83, 0xBB, 0x18, 0x02, 0x00, 0x00, 0x00	// cmp dword [rbx] + 0x218], 0
-};
-static const uint8_t doControlRepl[] = {
-	0x90, 0x90,							// nop; nop
-	0x90, 0x90,							// nop; nop
-	0x83, 0xBB, 0x18, 0x02, 0x00, 0x00, 0x00	// cmp dword [rbx] + 0x218], 0
-};
-
 NGFX *NGFX::callbackNGFX;
 
 void NGFX::init() {
@@ -102,6 +85,9 @@ void NGFX::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 				}
 			}
 		}
+
+		if (getKernelVersion() <= KernelVersion::Catalina)
+			kextList[IndexIONDRVSupport].switchOff();
 	} else {
 		for (size_t i = 0; i < arrsize(kextList); i++)
 			kextList[i].switchOff();
@@ -129,18 +115,8 @@ bool NGFX::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t a
 	}
 
 	if (kextList[IndexIONDRVSupport].loadIndex == index) {
-		if (getKernelVersion() > KernelVersion::Catalina) {
-			KernelPatcher::LookupPatch patch {&kextList[IndexIONDRVSupport], doControlFind, doControlRepl, sizeof(doControlFind), 1};
-
-			patcher.applyLookupPatch(&patch);
-
-			KernelPatcher::Error rc = patcher.getError();
-
-			if (rc == KernelPatcher::Error::NoError) { return true; }
-
-			SYSLOG("ngfx", "failed to apply IONDRVFramebuffer::_doControl() patch [err code %d]", rc);
-			patcher.clearError();
-		}
+		KernelPatcher::RouteRequest request("__ZN17IONDRVFramebuffer10_doControlEPS_jPv", wrapNdrvDoControl, orgNdrvDoControl);
+		patcher.routeMultiple(index, &request, 1, address, size);
 	}
 
 	return false;
@@ -366,4 +342,29 @@ IOService *NGFX::wrapStartupWebProbe(IOService *that, IOService *provider, SInt3
 	}
 
 	return FunctionCast(wrapStartupWebProbe, callbackNGFX->orgStartupWebProbe)(that, provider, score);
+}
+
+// This is a hack to let us access protected properties.
+struct NDRVFramebufferViewer : public IONDRVFramebuffer {
+	static UInt32 &getState(IONDRVFramebuffer *fb) {
+		return static_cast<NDRVFramebufferViewer *>(fb)->ndrvState;
+	}
+};
+
+IOReturn NGFX::wrapNdrvDoControl(IONDRVFramebuffer *fb, UInt32 code, void *params) {
+	// Suppress debug(?) noise from IONDRVFramebuffer::_doControl( IONDRVFramebuffer * fb, UInt32 code, void * params )
+	// when function was compiled with #define IONDRVCHECK 1.
+	// Ref: https://opensource.apple.com/source/IOGraphics/IOGraphics-585/IONDRVSupport/IONDRVFramebuffer.cpp.auto.html
+
+	if (code == cscSetHardwareCursor || code == cscDrawHardwareCursor) {
+		if (NDRVFramebufferViewer::getState(fb) == 0)
+			return kIOReturnNotOpen;
+
+		IONDRVControlParameters pb;
+		pb.code = code;
+		pb.params = params;
+		return fb->doDriverIO(/*ID*/ 1, &pb, kIONDRVControlCommand, kIONDRVImmediateIOCommandKind);
+	}
+
+	return FunctionCast(wrapNdrvDoControl, callbackNGFX->orgNdrvDoControl)(fb, code, params);
 }

--- a/WhateverGreen/kern_ngfx.hpp
+++ b/WhateverGreen/kern_ngfx.hpp
@@ -13,6 +13,7 @@
 #include <Headers/kern_patcher.hpp>
 #include <Headers/kern_devinfo.hpp>
 #include <IOKit/IOService.h>
+#include <IOKit/ndrvsupport/IONDRVFramebuffer.h>
 
 // Assembly exports for restoreLegacyOptimisations
 extern "C" bool wrapVaddrPreSubmitTrampoline(void *that);
@@ -107,6 +108,11 @@ private:
 	mach_vm_address_t orgStartupWebProbe {};
 
 	/**
+	 *  Original IONDRVFramebuffer::_doControl function
+	 */
+	mach_vm_address_t orgNdrvDoControl {};
+
+	/**
 	 *  Restore legacy optimisations from 10.13.0, which fix lags for Kepler GPUs.
 	 *  For Web drivers it is very experimental, since they have a lot of additional different (broken) code.
 	 *
@@ -152,6 +158,12 @@ private:
 	 *  NVDAStartup::probe wrapper used to force-enable web-drivers
 	 */
 	static IOService *wrapStartupWebProbe(IOService *that, IOService *provider, SInt32 *score);
+
+	/**
+	 *  IONDRVFramebuffer::_doControl wrapper used to avoid debug spam
+	 */
+
+	static IOReturn wrapNdrvDoControl(IONDRVFramebuffer *fb, UInt32 code, void *params);
 };
 
 #endif /* kern_ngfx_hpp */


### PR DESCRIPTION
When _doControl() complied with #define IONDRVCHECK 1, it produce a lot of debug noise on every csc{Set,Draw}HardwareCursor action in system logs.