### PR TITLE
Update FAQ.Intel.en.md on Haswell graphics

### DIFF
--- a/Manual/FAQ.IntelHD.en.md
+++ b/Manual/FAQ.IntelHD.en.md
@@ -739,7 +739,7 @@ Mobile: 1, PipeCount: 3, PortCount: 1, FBMemoryCount: 1
 - Empty Framebuffer:
   - `0x04120004` (default)
   
-For desktop HD4400 and mobile HD4200/HD4400 (**not the HD4600**) need fake the `device-id` `12040000` for `IGPU`.  
+For desktop HD4400 and mobile HD4400 (**not the HD 4200 neither HD4600**) need fake the `device-id` `12040000` for `IGPU`.  
 ![](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/Img/hsw_igpu.png)  
 
 

--- a/Manual/FAQ.IntelHD.en.md
+++ b/Manual/FAQ.IntelHD.en.md
@@ -739,7 +739,7 @@ Mobile: 1, PipeCount: 3, PortCount: 1, FBMemoryCount: 1
 - Empty Framebuffer:
   - `0x04120004` (default)
   
-For desktop HD4400 and mobile HD4200/HD4400/HD4600 need fake the `device-id` `12040000` for `IGPU`.  
+For desktop HD4400 and mobile HD4200/HD4400 (**not the HD4600**) need fake the `device-id` `12040000` for `IGPU`.  
 ![](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/Img/hsw_igpu.png)  
 
 


### PR DESCRIPTION
Only the HD4400 needs to spoof the `device-id`, so the wiki was updated accordingly

This is mentioned here: https://dortania.github.io/GPU-Buyers-Guide/modern-gpus/intel-gpu.html#haswell-4xxx

and also confirmed by khronokernel here: 

![Screenshot 2021-05-19 at 17 47 04](https://user-images.githubusercontent.com/46293832/118844108-fba91980-b8ca-11eb-9bab-6ba4c6c09e22.png)
