### PR TITLE
Update kern_model.cpp, add two Asus AMD R9 380 graphics cards

### DIFF
--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -739,6 +739,7 @@ static constexpr Model dev6939[] {
 	{Model::DetectSub, 0x148c, 0x9380, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x174b, 0xe308, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x1043, 0x0498, 0x0000, "AMD Radeon R9 380"},
+	{Model::DetectSub, 0x1043, 0x04e3, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x1462, 0x2015, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon R9 285"}
 };

--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -740,6 +740,7 @@ static constexpr Model dev6939[] {
 	{Model::DetectSub, 0x174b, 0xe308, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x1043, 0x0498, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x1043, 0x04e3, 0x0000, "AMD Radeon R9 380"},
+	{Model::DetectSub, 0x1043, 0x049a, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x1462, 0x2015, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon R9 285"}
 };


### PR DESCRIPTION
The new graphics card information is as follows:
* Asus(1043 049A) :  Asus R9 380 2GB STRIX
* Asus(1043 04E3) :  Asus R9 380 4GB STRIX GAMING

References:
https://gpu.userbenchmark.com/AMD-R9-380/Rating/3482