### PR TITLE
Substitute complicated PNLF _UID implementation

### DIFF
--- a/Manual/SSDT-PNLF.dsl
+++ b/Manual/SSDT-PNLF.dsl
@@ -29,11 +29,11 @@ DefinitionBlock ("", "SSDT", 2, "ACDT", "PNLF", 0x00000000)
                 // 99: Other (requires custom profile using WhateverGreen.kext via DeviceProperties applbkl-name and applbkl-data)
                 Name (_UID, Zero)  // _UID: Unique ID
                 Name (_STA, 0x0B)  // _STA: Status
+            }
 
-                Method (SUID, 1, NotSerialized)
-                {
-                    _UID = ToInteger (Arg0)
-                }
+            Method (SUID, 1, NotSerialized)
+            {
+                ^PNLF._UID = ToInteger (Arg0)
             }
         }
     }

--- a/Manual/SSDT-PNLF.dsl
+++ b/Manual/SSDT-PNLF.dsl
@@ -1,0 +1,41 @@
+// Adding PNLF device for WhateverGreen.kext and others.
+// This is a simplified PNLF version originally taken from RehabMan/OS-X-Clover-Laptop-Config repository:
+// https://raw.githubusercontent.com/RehabMan/OS-X-Clover-Laptop-Config/master/hotpatch/SSDT-PNLF.dsl
+// Rename GFX0 to anything else if your IGPU name is different.
+//
+// Licensed under GNU General Public License v2.0
+// https://github.com/RehabMan/OS-X-Clover-Laptop-Config/blob/master/License.md
+
+DefinitionBlock ("", "SSDT", 2, "ACDT", "PNLF", 0x00000000)
+{
+    External (_SB_.PCI0.GFX0, DeviceObj)    // (from opcode)
+
+    If (_OSI ("Darwin")) {
+        Scope (\_SB.PCI0.GFX0)
+        {
+            // For backlight control
+            Device (PNLF)
+            {
+             // Name(_ADR, Zero)
+                Name (_HID, EisaId ("APP0002"))  // _HID: Hardware ID
+                Name (_CID, "backlight")  // _CID: Compatible ID
+                // _UID is set depending on PWMMax to match profiles in WhateverGreen.kext https://github.com/acidanthera/WhateverGreen/blob/1.4.7/WhateverGreen/kern_weg.cpp#L32
+                // 14: Sandy/Ivy 0x710
+                // 15: Haswell/Broadwell 0xad9
+                // 16: Skylake/KabyLake 0x56c (and some Haswell, example 0xa2e0008)
+                // 17: custom LMAX=0x7a1
+                // 18: custom LMAX=0x1499
+                // 19: CoffeeLake 0xffff
+                // 99: Other (requires custom profile using WhateverGreen.kext via DeviceProperties applbkl-name and applbkl-data)
+                Name (_UID, Zero)  // _UID: Unique ID
+                Name (_STA, 0x0B)  // _STA: Status
+
+                Method (SUID, 1, NotSerialized)
+                {
+                    _UID = ToInteger (Arg0)
+                }
+            }
+        }
+    }
+}
+

--- a/WhateverGreen.xcodeproj/project.pbxproj
+++ b/WhateverGreen.xcodeproj/project.pbxproj
@@ -93,7 +93,6 @@
 		5B9131F2258A8EFB0008530D /* FAQ.IntelHD.en.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = FAQ.IntelHD.en.md; sourceTree = "<group>"; };
 		5B9131F3258A8F090008530D /* FAQ.IntelHD.cn.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = FAQ.IntelHD.cn.md; sourceTree = "<group>"; };
 		5B9131F4258A8F1C0008530D /* FAQ.OldPlugins.en.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = FAQ.OldPlugins.en.md; sourceTree = "<group>"; };
-		6FA3CCFC26EEAF2A00EE07F0 /* SSDT-PNLF.dsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SSDT-PNLF.dsl"; sourceTree = "<group>"; };
 		CE1970FD21C380DF00B02AB4 /* kern_nvhda.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_nvhda.cpp; sourceTree = "<group>"; };
 		CE1970FE21C380DF00B02AB4 /* kern_nvhda.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_nvhda.hpp; sourceTree = "<group>"; };
 		CE1F61B82432DEE800201DF4 /* kern_igfx_debug.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_igfx_debug.cpp; sourceTree = "<group>"; };
@@ -336,7 +335,6 @@
 				CE7FC0D020F6882400138088 /* FAQ.Shiki.zh_CN.md */,
 				CE271B4C1F319BD000D2BC1C /* reference.cpp */,
 				CEAEA1191F26905A00918651 /* Sample.dsl */,
-				6FA3CCFC26EEAF2A00EE07F0 /* SSDT-PNLF.dsl */,
 			);
 			path = Manual;
 			sourceTree = "<group>";

--- a/WhateverGreen.xcodeproj/project.pbxproj
+++ b/WhateverGreen.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		5B9131F2258A8EFB0008530D /* FAQ.IntelHD.en.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = FAQ.IntelHD.en.md; sourceTree = "<group>"; };
 		5B9131F3258A8F090008530D /* FAQ.IntelHD.cn.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = FAQ.IntelHD.cn.md; sourceTree = "<group>"; };
 		5B9131F4258A8F1C0008530D /* FAQ.OldPlugins.en.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = FAQ.OldPlugins.en.md; sourceTree = "<group>"; };
+		6FA3CCFC26EEAF2A00EE07F0 /* SSDT-PNLF.dsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SSDT-PNLF.dsl"; sourceTree = "<group>"; };
 		CE1970FD21C380DF00B02AB4 /* kern_nvhda.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_nvhda.cpp; sourceTree = "<group>"; };
 		CE1970FE21C380DF00B02AB4 /* kern_nvhda.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = kern_nvhda.hpp; sourceTree = "<group>"; };
 		CE1F61B82432DEE800201DF4 /* kern_igfx_debug.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = kern_igfx_debug.cpp; sourceTree = "<group>"; };
@@ -335,6 +336,7 @@
 				CE7FC0D020F6882400138088 /* FAQ.Shiki.zh_CN.md */,
 				CE271B4C1F319BD000D2BC1C /* reference.cpp */,
 				CEAEA1191F26905A00918651 /* Sample.dsl */,
+				6FA3CCFC26EEAF2A00EE07F0 /* SSDT-PNLF.dsl */,
 			);
 			path = Manual;
 			sourceTree = "<group>";

--- a/WhateverGreen/Info.plist
+++ b/WhateverGreen/Info.plist
@@ -71,6 +71,8 @@
 		<string>10.0.0</string>
 		<key>com.apple.kpi.unsupported</key>
 		<string>10.0.0</string>
+		<key>com.apple.iokit.IOACPIFamily</key>
+		<string>1.0.0d1</string>
 		<key>com.apple.iokit.IOPCIFamily</key>
 		<string>1.0.0b1</string>
 		<key>as.vit9696.Lilu</key>

--- a/WhateverGreen/kern_weg.cpp
+++ b/WhateverGreen/kern_weg.cpp
@@ -468,7 +468,8 @@ void WEG::processBuiltinProperties(IORegistryEntry *device, DeviceInfo *info) {
 		}
 
 		if (auto adev = OSDynamicCast(IOACPIPlatformDevice, obj->getProperty("acpi-device"))) {
-			auto pnlf = OSDynamicCast(IOACPIPlatformDevice, adev->childFromPath("PNLF", gIOACPIPlane));
+			auto child = adev->childFromPath("PNLF", gIOACPIPlane);
+			auto pnlf = OSDynamicCast(IOACPIPlatformDevice, child);
 			if (pnlf) {
 				DBGLOG("weg", "found PNLF at %s", safeString(pnlf->getName()));
 				IOReturn ret;
@@ -492,6 +493,7 @@ void WEG::processBuiltinProperties(IORegistryEntry *device, DeviceInfo *info) {
 					pnlf->setProperty("_UID", result);
 				OSSafeReleaseNULL(result);
 			}
+			OSSafeReleaseNULL(child);
 		}
 	} else {
 		SYSLOG("weg", "invalid IGPU device type");

--- a/WhateverGreen/kern_weg.cpp
+++ b/WhateverGreen/kern_weg.cpp
@@ -11,6 +11,7 @@
 #include <Headers/kern_cpu.hpp>
 #include "kern_weg.hpp"
 
+#include <IOKit/acpi/IOACPIPlatformDevice.h>
 #include <IOKit/graphics/IOFramebuffer.h>
 
 // This is a hack to let us access protected properties.
@@ -375,6 +376,47 @@ void WEG::processKext(KernelPatcher &patcher, size_t index, mach_vm_address_t ad
 		return;
 }
 
+uint32_t processUID(uint32_t real) {
+	uint32_t uid = 0;
+	// list from SSDT-PNLF, use CpuGeneration instead?
+	switch (real) {
+		// Sandy HD3000
+		case 0x010b: case 0x0102:
+		case 0x0106: case 0x1106: case 0x1601: case 0x0116: case 0x0126:
+		case 0x0112: case 0x0122:
+		// Ivy
+		case 0x0152: case 0x0156: case 0x0162: case 0x0166:
+		case 0x016a:
+		// Arrandale
+		case 0x0046: case 0x0042:
+			uid = 14;
+			break;
+
+		// CoffeeLake and Whiskey Lake and CometLake and IceLake
+		case 0x3e9b: case 0x3ea5: case 0x3e92: case 0x3e91: case 0x3ea0: case 0x3ea6: case 0x3e98:
+		case 0x9bc8: case 0x9bc5: case 0x9bc4: case 0xff05: case 0x8a70: case 0x8a71: case 0x8a51:
+		case 0x8a5c: case 0x8a5d: case 0x8a52: case 0x8a53: case 0x8a56: case 0x8a5a: case 0x8a5b:
+		case 0x9b41: case 0x9b21: case 0x9bca: case 0x9ba4:
+			uid = 19;
+			break;
+
+		// Haswell
+		case 0x0d26: case 0x0a26: case 0x0d22: case 0x0412: case 0x0416: case 0x0a16: case 0x0a1e: case 0x0a2e: case 0x041e: case 0x041a:
+		// Broadwell
+		case 0x0bd1: case 0x0bd2: case 0x0bd3: case 0x1606: case 0x160e: case 0x1616: case 0x161e: case 0x1626: case 0x1622: case 0x1612: case 0x162b:
+			uid = 15;
+			break;
+
+		// assume Skylake/KabyLake/KabyLake-R
+		// 0x1916, 0x191E, 0x1926, 0x1927, 0x1912, 0x1932, 0x1902, 0x1917, 0x191b,
+		// 0x5916, 0x5912, 0x591b, others...
+		default:
+			uid = 16;
+			break;
+	}
+	return uid;
+}
+
 void WEG::processBuiltinProperties(IORegistryEntry *device, DeviceInfo *info) {
 	auto name = device->getName();
 
@@ -422,6 +464,33 @@ void WEG::processBuiltinProperties(IORegistryEntry *device, DeviceInfo *info) {
 				KernelPatcher::routeVirtual(obj, WIOKit::PCIConfigOffset::ConfigRead16, wrapConfigRead16, &orgConfigRead16);
 				KernelPatcher::routeVirtual(obj, WIOKit::PCIConfigOffset::ConfigRead32, wrapConfigRead32, &orgConfigRead32);
 				DBGLOG("weg", "hooked configRead read methods!");
+			}
+		}
+
+		if (auto adev = OSDynamicCast(IOACPIPlatformDevice, obj->getProperty("acpi-device"))) {
+			auto pnlf = OSDynamicCast(IOACPIPlatformDevice, adev->childFromPath("PNLF", gIOACPIPlane));
+			if (pnlf) {
+				DBGLOG("weg", "found PNLF at %s", safeString(pnlf->getName()));
+				IOReturn ret;
+				ret = pnlf->validateObject("SUID");
+				if (ret == kIOReturnSuccess) {
+					uint32_t target = processUID(realDevice);
+					OSObject *params[] = { OSNumber::withNumber(target, 32) };
+					ret = pnlf->evaluateObject("SUID", nullptr, params, 1);
+					if (ret == kIOReturnSuccess) {
+						DBGLOG("weg", "PNLF _UID set to 0x%x", target);
+					} else {
+						SYSLOG("weg", "failed to set PNLF _UID");
+					}
+					params[0]->release();
+				} else {
+					DBGLOG("weg", "PNLF doesn't support _UID set");
+				}
+				OSObject *result = nullptr;
+				ret = pnlf->evaluateObject("_UID", &result);
+				if (ret == kIOReturnSuccess)
+					pnlf->setProperty("_UID", result);
+				OSSafeReleaseNULL(result);
 			}
 		}
 	} else {


### PR DESCRIPTION
Current `SSDT-PNLF` relies on PCI and BAR access from ACPI space. However, only proper `_UID` is required for most cases. Meanwhile, some workaround are also available in WhateverGreen.

By moving `_UID` identification to WhateverGreen, it's possible to make `PNLF` device a simple stub matched by `AppleIntelPanel`. Purposed solution is to use a ACPI method `SUID` that accepts desired `_UID` from WhateverGreen. It might need extra work to replace it by patching `AppleIntelPanel::start` that evaluate `_UID`.

Sample DSDT attached in the commit but will remove later. 

Tested on 8086:9b41 (faked to 3e9b, CFL) and 8086:5927 (fake to 5926, KBL-R).