### PR TITLE
Changed the default delay of optimizing display data buffer allocations from 0 to 1 second

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 WhateverGreen Changelog
 =======================
+#### v1.5.5
+- Changed the default delay of optimizing display data buffer allocations from 0 to 1 second to fix the issue that both internal and external displays flicker on some Ice Lake-based laptops. (Thanks @m0d16l14n1)
+
 #### v1.5.4
 - Added the fix for the short period garbled screen after the system boots on Ice Lake platforms. (by @0xFireWolf, also thanks @m0d16l14n1 and @kingo132)
 

--- a/Manual/FAQ.IntelHD.cn.md
+++ b/Manual/FAQ.IntelHD.cn.md
@@ -2026,6 +2026,13 @@ igfx: @ (DBG) BLS: [COMM] Processing the request: Current = 0x00014ead; Target =
 为核显添加 `enable-dbuf-early-optimizer` 属性或者直接使用 `-igfxdbeo` 启动参数以修复 Ice Lake 笔记本开机后内屏短暂花屏的问题。
 若发现内核日志记录了如下 DBUF 以及 Pipe Underrun 相关的错误信息，请启用此补丁来修复这些错误。
 
+此补丁通过提前调用优化显示缓冲区分配的函数来修复 DBUF 相关错误。
+用户可通过 `dbuf-optimizer-delay` 设备属性来指定具体的延迟时间（单位为秒，值类型为`Data`）。
+若用户未指定此属性，*WEG* 将使用如下所述的默认值。
+
+社区用户反馈 1 到 3 秒的延迟可在不影响外接显示器的情况下修复 DBUF 相关错误，而 *WEG* v1.5.4 所用的默认 0 秒延迟可能会导致部分笔记本外接显示器时内屏外屏同时花屏的问题。
+从 v1.5.5 开始，默认的延迟时间改为 1 秒，这样用户在通常情况下无需手动添加设备属性来修改延迟时间。
+
 <details>
 <summary>包含 DBUF 以及 Pipe Underrun 错误信息的内核日志</summary>
 

--- a/Manual/FAQ.IntelHD.en.md
+++ b/Manual/FAQ.IntelHD.en.md
@@ -2666,6 +2666,14 @@ Add the `enable-dbuf-early-optimizer` property to `IGPU` or use the `-igfxdbeo` 
 otherwise your builtin display remains garbled for 7 to 15 seconds after the system boots.
 You need this fix if you observe a bunch of errors mentioning "DBUF" and "pipe underrun" in the kernel log.
 
+This fix works by calling the function that optimizes the display data buffer allocations early.
+You may specify the delay in seconds (value of type `Data`) via the `dbuf-optimizer-delay` property.
+If the property is not specified, the default value will be used (see below).
+
+The community reports that a delay of 1 to 3 seconds is adequate for avoiding the underrun issue on the builtin display without having negative impacts on external displays,
+and that the default delay of 0 second used in *WEG* v1.5.4 may lead to both internal and external displays flickering on some laptops.
+Starting from v1.5.5, the default delay is changed to 1 second, so in most cases users do not have to specify the delay manually.
+
 <details>
 <summary>Sample kernel log that contains DBUF-related errors</summary>
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ indices of connectors for which online status is enforced. Format is similar to 
 - `-igfxblr` boot argument (and `enable-backlight-registers-fix` property) to fix backlight registers on KBL, CFL and ICL platforms.
 - `-igfxmpc` boot argument (`enable-max-pixel-clock-override` and `max-pixel-clock-frequency` properties) to increase max pixel clock (as an alternative to patching CoreDisplay.framework).
 - `-igfxbls` boot argument (and `enable-backlight-smoother` property) to make brightness transitions smoother on IVB+ platforms. [Read the manual](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/FAQ.IntelHD.en.md#customize-the-behavior-of-the-backlight-smoother-to-improve-your-experience)
-- `-igfxdbeo` boot argument (and `enable-dbuf-early-optimizer` property) to fix the Display Data Buffer (DBUF) issues on ICL+ platforms.
+- `-igfxdbeo` boot argument (and `enable-dbuf-early-optimizer` property) to fix the Display Data Buffer (DBUF) issues on ICL+ platforms. [Read the manual](https://github.com/acidanthera/WhateverGreen/blob/master/Manual/FAQ.IntelHD.en.md#fix-the-issue-that-the-builtin-display-remains-garbled-after-the-system-boots-on-icl-platforms)
 
 #### Credits
 

--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -1774,9 +1774,20 @@ private:
 		static constexpr const char* kOptimizerTime = "DBUFOptimizeTime";
 		
 		/**
+		 *  The default optimizer delay is 1 second
+		 *
+		 *  @note The community reports that the previous default delay (0 second) used v1.5.4
+		 *        may result in both internal and external displays flickering on some laptops.
+		 *        Their experiment suggests that a delay of 1 to 3 seconds seems to be safe and solves
+		 *        the underrun issue on the builtin display without having impacts on the external ones.
+		 *  @note Thanks @m0d16l14n1 for the suggestion and collecting results from other testers.
+		 */
+		static constexpr uint32_t kDefaultOptimizerTime = 1;
+		
+		/**
 		 *  Specify the amount of time in seconds to delay the execution of optimizing the display data buffer allocation
 		 */
-		uint32_t optimizerTime {0};
+		uint32_t optimizerTime {kDefaultOptimizerTime};
 		
 		/**
 		 *  Original AppleIntelFramebufferController::getFeatureControl function


### PR DESCRIPTION
#### Abstract

This is a follow-up for the previous PR (https://github.com/acidanthera/WhateverGreen/pull/92) that fixes the garbled screen on Intel Ice Lake platforms.

The community reports that a delay of 1 to 3 seconds is adequate for avoiding the pipe underrun issue on the builtin display without having negative impacts on external displays, and that the default delay of 0 second used in v1.5.4 may lead to both internal and external displays flickering on some laptops.

This PR changes the default delay to 1 second and adds documentation for a hidden device property `dbuf-optimizer-delay` introduced in the previous PR that allows users to specify a custom delay value.

Thank you.

-- FireWolf
Oct 8, 2021