### PR TITLE
Inverted logic for GVA support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 WhateverGreen Changelog
 =======================
+#### v1.5.8
+- Inverted logic for GVA support, which is now disabled by default and can be enabled by `enable-gva-support`.
+
 #### v1.5.7
 - Fixed maximum backlight level on Ice Lake IGPUs
 

--- a/WhateverGreen/kern_rad.cpp
+++ b/WhateverGreen/kern_rad.cpp
@@ -150,12 +150,11 @@ void RAD::processKernel(KernelPatcher &patcher, DeviceInfo *info) {
 	for (size_t i = 0; i < info->videoExternal.size(); i++) {
 		if (info->videoExternal[i].vendor == WIOKit::VendorID::ATIAMD) {
 			if (!hasAMD) {
-				enableGvaSupport = getKernelVersion() >= KernelVersion::Mojave;
 				hasAMD = true;
 			}
 
-			if (info->videoExternal[i].video->getProperty("disable-gva-support"))
-				enableGvaSupport = false;
+			if (info->videoExternal[i].video->getProperty("enable-gva-support"))
+				enableGvaSupport = true;
 
 			// When injecting values into device properties one cannot specify boolean types.
 			// Provide special support for Force_Load_FalconSMUFW.


### PR DESCRIPTION
By enabling GVA support by default it may cause problems like on https://github.com/acidanthera/bugtracker/issues/1867. Thus, the logic should be inverted, which makes the default behaviour being disabled. To enable GVA support, property `enable-gva-support` can be set, while the meaning of `radgva=0 (disabled) / 1 (enabled)` remains unchanged.