### PR TITLE
Remove profile 2 from VTSupportedProfileArray

### DIFF
--- a/WhateverGreen/kern_igfx.hpp
+++ b/WhateverGreen/kern_igfx.hpp
@@ -1948,6 +1948,11 @@ private:
 	static OSObject *wrapCopyExistingServices(OSDictionary *matching, IOOptionBits inState, IOOptionBits options);
 
 	/**
+	 *  Apply patches for Skylake when spoofing Kaby Lake
+	 */
+	static bool applySklAsKblPatches(IOService *that);
+
+	/**
 	 *  IntelAccelerator::start wrapper to support vesa mode, force OpenGL, prevent fw loading, etc.
 	 */
 	static bool wrapAcceleratorStart(IOService *that, IOService *provider);


### PR DESCRIPTION
In addition to the removal of vp9 flag `IOGVAXDecode` on SKL when spoofing as KBL, profile 2 under `VTSupportedProfileArray` in `IOGVAHEVCDecodeCapabilities` also needs to be removed to avoid flickering when decoding HEVC encoded videos.

CC and Thanks to @dhinakg for the code infrastructure again!