### PR TITLE
Update kern_model.cpp with W7170M/S7100X for iMac 

### DIFF
--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -727,6 +727,7 @@ static constexpr Model dev6920[] {
 };
 
 static constexpr Model dev6921[] {
+	{Model::DetectSub, 0x1028, 0x16DA, 0x0000, "AMD FirePro W7170M"}
 	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon R9 M295X"}
 };
 
@@ -736,6 +737,7 @@ static constexpr Model dev6938[] {
 };
 
 static constexpr Model dev6939[] {
+	{Model::DetectSub, 0x1002, 0x0b00, 0x0000, "AMD FirePro S7100X"}
 	{Model::DetectSub, 0x148c, 0x9380, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x174b, 0xe308, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x1043, 0x0498, 0x0000, "AMD Radeon R9 380"},

--- a/WhateverGreen/kern_model.cpp
+++ b/WhateverGreen/kern_model.cpp
@@ -727,7 +727,7 @@ static constexpr Model dev6920[] {
 };
 
 static constexpr Model dev6921[] {
-	{Model::DetectSub, 0x1028, 0x16DA, 0x0000, "AMD FirePro W7170M"}
+	{Model::DetectSub, 0x1028, 0x16DA, 0x0000, "AMD FirePro W7170M"},
 	{Model::DetectDef, 0x0000, 0x0000, 0x0000, "AMD Radeon R9 M295X"}
 };
 
@@ -737,7 +737,7 @@ static constexpr Model dev6938[] {
 };
 
 static constexpr Model dev6939[] {
-	{Model::DetectSub, 0x1002, 0x0b00, 0x0000, "AMD FirePro S7100X"}
+	{Model::DetectSub, 0x1002, 0x0b00, 0x0000, "AMD FirePro S7100X"},
 	{Model::DetectSub, 0x148c, 0x9380, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x174b, 0xe308, 0x0000, "AMD Radeon R9 380"},
 	{Model::DetectSub, 0x1043, 0x0498, 0x0000, "AMD Radeon R9 380"},


### PR DESCRIPTION
Appreciate the attached proposed modifications to the next version installment to allow for specific string identification of the AMD W7170M and AMD S7100X -MXM based cards. I've been able to modify the OBJ-table in the vbios to successfully initialize the cards in the iMac environment. However, currently, only the best guess default ('def') or the generic AMD R9xxx is displayed. Thank you.