### PR TITLE
Fixed short-circuit evaluation from brightness bound overrides.

### DIFF
--- a/WhateverGreen/kern_igfx_backlight.cpp
+++ b/WhateverGreen/kern_igfx_backlight.cpp
@@ -1355,8 +1355,8 @@ void IGFX::BacklightSmoother::processKernel(KernelPatcher &patcher, DeviceInfo *
 		DBGLOG("igfx", "BLS: User requested threshold = %u.", threshold);
 	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-queue-size", queueSize))
 		DBGLOG("igfx", "BLS: User requested queue size = %u.", queueSize);
-	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-lowerbound", brightnessRange.first) ||
-		WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-upperbound", brightnessRange.second))
+	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-lowerbound", brightnessRange.first) ? true
+		: WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-upperbound", brightnessRange.second))
 		DBGLOG("igfx", "BLS: User requested brightness range = [%u, %u].", brightnessRange.first, brightnessRange.second);
 	
 	// Sanitize user configurations


### PR DESCRIPTION
Currently, if both `backlight-smoother-lowerbound` and `backlight-smoother-upperbound` are set, the upper bound will be ignored due to the OR evaluation in [this](https://github.com/acidanthera/WhateverGreen/blob/21c7ffb6fda24443b22fc5d9cfc6b2cdbfb3c542/WhateverGreen/kern_igfx_backlight.cpp#L1358C2-L1359C103) `if` statement.

Added a ternary operator in place to force both bound checks.