### PR TITLE
Fixed short-circuit evaluation from brightness bound overrides.

### DIFF
--- a/WhateverGreen/kern_igfx_backlight.cpp
+++ b/WhateverGreen/kern_igfx_backlight.cpp
@@ -1355,7 +1355,7 @@ void IGFX::BacklightSmoother::processKernel(KernelPatcher &patcher, DeviceInfo *
 		DBGLOG("igfx", "BLS: User requested threshold = %u.", threshold);
 	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-queue-size", queueSize))
 		DBGLOG("igfx", "BLS: User requested queue size = %u.", queueSize);
-	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-lowerbound", brightnessRange.first) ||
+	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-lowerbound", brightnessRange.first) |
 		WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-upperbound", brightnessRange.second))
 		DBGLOG("igfx", "BLS: User requested brightness range = [%u, %u].", brightnessRange.first, brightnessRange.second);
 	

--- a/WhateverGreen/kern_igfx_backlight.cpp
+++ b/WhateverGreen/kern_igfx_backlight.cpp
@@ -1355,9 +1355,10 @@ void IGFX::BacklightSmoother::processKernel(KernelPatcher &patcher, DeviceInfo *
 		DBGLOG("igfx", "BLS: User requested threshold = %u.", threshold);
 	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-queue-size", queueSize))
 		DBGLOG("igfx", "BLS: User requested queue size = %u.", queueSize);
-	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-lowerbound", brightnessRange.first) |
-		WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-upperbound", brightnessRange.second))
-		DBGLOG("igfx", "BLS: User requested brightness range = [%u, %u].", brightnessRange.first, brightnessRange.second);
+	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-lowerbound", brightnessRange.first))
+		DBGLOG("igfx", "BLS: User requested brightness lower bound = %u.", brightnessRange.first);
+	if (WIOKit::getOSDataValue(info->videoBuiltin, "backlight-smoother-upperbound", brightnessRange.second))
+		DBGLOG("igfx", "BLS: User requested brightness upper bound = %u.", brightnessRange.second);
 	
 	// Sanitize user configurations
 	if (steps == 0) {


### PR DESCRIPTION
Currently, if both `backlight-smoother-lowerbound` and `backlight-smoother-upperbound` are set, the upper bound will be ignored due to the OR evaluation in [this](https://github.com/acidanthera/WhateverGreen/blob/21c7ffb6fda24443b22fc5d9cfc6b2cdbfb3c542/WhateverGreen/kern_igfx_backlight.cpp#L1358C2-L1359C103) `if` statement.

Changed the _logical_ OR to a _bitwise_ OR to force both bound checks.